### PR TITLE
Add Donation Form Goal module

### DIFF
--- a/languages/give-divi.pot
+++ b/languages/give-divi.pot
@@ -15,20 +15,192 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/Divi/Modules/DonationForm/Module.php:17
+#: src/Divi/Repositories/Forms.php:42
+msgid "Full form"
+msgstr ""
+
+#: src/Divi/Repositories/Forms.php:43
+msgid "Modal"
+msgstr ""
+
+#: src/Divi/Repositories/Forms.php:44
+msgid "Reveal"
+msgstr ""
+
+#: src/Divi/Repositories/Forms.php:45
+msgid "One Button Launch"
+msgstr ""
+
+#: src/Divi/Routes/Endpoint.php:27
+msgid "You dont have the right permissions to use Give Divi Add-on"
+msgstr ""
+
+#: src/Divi/Routes/RenderDonationForm.php:69, src/Divi/Routes/RenderFormGoal.php:65
+msgid "Donation Form id"
+msgstr ""
+
+#: src/Divi/Routes/RenderDonationForm.php:73
+msgid "Donation Form  display style"
+msgstr ""
+
+#: src/Divi/Routes/RenderDonationForm.php:77
+msgid "Show Donation Form title"
+msgstr ""
+
+#: src/Divi/Routes/RenderDonationForm.php:81
+msgid "Show Donation Form goal"
+msgstr ""
+
+#: src/Divi/Routes/RenderDonorWall.php:137, src/Divi/Modules/DonorWall/Module.php:28
+msgid "Donors per page"
+msgstr ""
+
+#: src/Divi/Routes/RenderDonorWall.php:141, src/Divi/Modules/DonorWall/Module.php:40
+msgid "Donor IDs"
+msgstr ""
+
+#: src/Divi/Routes/RenderDonorWall.php:145, src/Divi/Modules/DonorWall/Module.php:45
+msgid "Form ID"
+msgstr ""
+
+#: src/Divi/Routes/RenderDonorWall.php:149, src/Divi/Modules/DonorWall/Module.php:51
+msgid "Order By"
+msgstr ""
+
+#: src/Divi/Routes/RenderDonorWall.php:153, src/Divi/Modules/DonorWall/Module.php:61
+msgid "Order"
+msgstr ""
+
+#: src/Divi/Routes/RenderDonorWall.php:157, src/Divi/Modules/DonorWall/Module.php:71
+msgid "Columns"
+msgstr ""
+
+#: src/Divi/Routes/RenderDonorWall.php:161, src/Divi/Modules/DonorWall/Module.php:84
+msgid "Avatar Size"
+msgstr ""
+
+#: src/Divi/Routes/RenderDonorWall.php:165, src/Divi/Modules/DonorWall/Module.php:96
+msgid "Show Avatar"
+msgstr ""
+
+#: src/Divi/Routes/RenderDonorWall.php:169, src/Divi/Modules/DonorWall/Module.php:103
+msgid "Show Name"
+msgstr ""
+
+#: src/Divi/Routes/RenderDonorWall.php:173, src/Divi/Modules/DonorWall/Module.php:110
+msgid "Show Company Name"
+msgstr ""
+
+#: src/Divi/Routes/RenderDonorWall.php:177, src/Divi/Modules/DonorWall/Module.php:117
+msgid "Show Total"
+msgstr ""
+
+#: src/Divi/Routes/RenderDonorWall.php:181, src/Divi/Modules/DonorWall/Module.php:124
+msgid "Show Time"
+msgstr ""
+
+#: src/Divi/Routes/RenderDonorWall.php:185, src/Divi/Modules/DonorWall/Module.php:131
+msgid "Show Comments"
+msgstr ""
+
+#: src/Divi/Routes/RenderDonorWall.php:189, src/Divi/Modules/DonorWall/Module.php:138
+msgid "Show Anonymous"
+msgstr ""
+
+#: src/Divi/Routes/RenderDonorWall.php:193
+msgid "Show Only Donors with Comments"
+msgstr ""
+
+#: src/Divi/Routes/RenderDonorWall.php:197, src/Divi/Modules/DonorWall/Module.php:152
+msgid "Comment Length"
+msgstr ""
+
+#: src/Divi/Routes/RenderDonorWall.php:201, src/Divi/Modules/DonorWall/Module.php:164, src/Divi/Modules/DonorWall/Module.php:201
+msgid "Read More Text"
+msgstr ""
+
+#: src/Divi/Routes/RenderDonorWall.php:205, src/Divi/Modules/DonorWall/Module.php:169, src/Divi/Modules/DonorWall/Module.php:202
+msgid "Load More Text"
+msgstr ""
+
+#: src/Divi/Routes/RenderFormGoal.php:69
+msgid "Show Goal Text"
+msgstr ""
+
+#: src/Divi/Routes/RenderFormGoal.php:73
+msgid "Show Goal Bar"
+msgstr ""
+
+#: src/Divi/Modules/DonationForm/Module.php:36
 msgid "Give Donation Form"
 msgstr ""
 
-#: src/Divi/Modules/DonationForm/Module.php:23
+#: src/Divi/Modules/DonationForm/Module.php:60, src/Divi/Modules/FormGoal/Module.php:61
 msgid "Select Donation form"
 msgstr ""
 
-#: src/Divi/Modules/DonationForm/Module.php:26
-msgid "Select Donation Form"
+#: src/Divi/Modules/DonationForm/Module.php:63, src/Divi/Modules/FormGoal/Module.php:64
+msgid "Select form"
+msgstr ""
+
+#: src/Divi/Modules/DonationForm/Module.php:66
+msgid "Donation form format"
+msgstr ""
+
+#: src/Divi/Modules/DonationForm/Module.php:76
+msgid "Display form title"
+msgstr ""
+
+#: src/Divi/Modules/DonationForm/Module.php:86
+msgid "Display Donation goal"
+msgstr ""
+
+#: src/Divi/Modules/DonorWall/Module.php:17
+msgid "Give Donor wall"
+msgstr ""
+
+#: src/Divi/Modules/DonorWall/Module.php:55
+msgid "Descending"
+msgstr ""
+
+#: src/Divi/Modules/DonorWall/Module.php:56
+msgid "Ascending"
+msgstr ""
+
+#: src/Divi/Modules/DonorWall/Module.php:65
+msgid "Donation Amount"
+msgstr ""
+
+#: src/Divi/Modules/DonorWall/Module.php:66
+msgid "Date Created"
+msgstr ""
+
+#: src/Divi/Modules/DonorWall/Module.php:75
+msgid "Best Fit"
+msgstr ""
+
+#: src/Divi/Modules/DonorWall/Module.php:145
+msgid "Only Donors with Comments"
+msgstr ""
+
+#: src/Divi/Modules/FormGoal/Module.php:47
+msgid "Give Form Goal"
+msgstr ""
+
+#: src/Divi/Modules/FormGoal/Module.php:67
+msgid "Show text"
+msgstr ""
+
+#: src/Divi/Modules/FormGoal/Module.php:77
+msgid "Show bar"
 msgstr ""
 
 #: src/Divi/resources/views/admin/notices/divi-inactive-error.php:5, src/Divi/resources/views/admin/notices/give-inactive.php:5, src/Divi/resources/views/admin/notices/give-version-error.php:4
 msgid "Activation Error:"
+msgstr ""
+
+#: src/Divi/resources/views/admin/notices/divi-inactive-error.php:7
+msgid "add-on requires Divi builder to be activated."
 msgstr ""
 
 #: src/Divi/resources/views/admin/notices/give-inactive.php:6, src/Divi/resources/views/admin/notices/give-version-error.php:6

--- a/src/Divi/AddonServiceProvider.php
+++ b/src/Divi/AddonServiceProvider.php
@@ -10,8 +10,6 @@ use GiveDivi\Addon\Language;
 use GiveDivi\Addon\ActivationBanner;
 use GiveDivi\Divi\Helpers\Assets;
 use GiveDivi\Divi\Helpers\Modules;
-use GiveDivi\Divi\Routes\RenderDonationForm;
-use GiveDivi\Divi\Routes\RenderDonorWall;
 
 /**
  * Service provider responsible for add-on initialization.
@@ -42,8 +40,9 @@ class AddonServiceProvider implements ServiceProvider {
 		}
 
 		// Rest routes
-		Hooks::addAction( 'rest_api_init', RenderDonationForm::class, 'registerRoute' );
-		Hooks::addAction( 'rest_api_init', RenderDonorWall::class, 'registerRoute' );
+		foreach ( Modules::getRoutes() as $moduleRoute ) {
+			Hooks::addAction( 'rest_api_init', $moduleRoute, 'registerRoute' );
+		}
 
 		// Load GiveWP Divi modules
 		add_action(

--- a/src/Divi/Helpers/Modules.php
+++ b/src/Divi/Helpers/Modules.php
@@ -5,9 +5,11 @@ namespace GiveDivi\Divi\Helpers;
 // Modules
 use GiveDivi\Divi\Modules\DonationForm\Module as DonationFormModule;
 use GiveDivi\Divi\Modules\DonorWall\Module as DonorWallModule;
+use GiveDivi\Divi\Modules\FormGoal\Module as FormGoalModule;
 // Module routes Routes
 use GiveDivi\Divi\Routes\RenderDonationForm;
 use GiveDivi\Divi\Routes\RenderDonorWall;
+use GiveDivi\Divi\Routes\RenderFormGoal;
 
 /**
  * Class Modules
@@ -28,6 +30,10 @@ class Modules {
 			[
 				'module' => DonorWallModule::class,
 				'route'  => RenderDonorWall::class,
+			],
+			[
+				'module' => FormGoalModule::class,
+				'route'  => RenderFormGoal::class,
 			],
 		];
 	}

--- a/src/Divi/Helpers/Modules.php
+++ b/src/Divi/Helpers/Modules.php
@@ -2,18 +2,62 @@
 
 namespace GiveDivi\Divi\Helpers;
 
+// Modules
 use GiveDivi\Divi\Modules\DonationForm\Module as DonationFormModule;
 use GiveDivi\Divi\Modules\DonorWall\Module as DonorWallModule;
+// Module routes Routes
+use GiveDivi\Divi\Routes\RenderDonationForm;
+use GiveDivi\Divi\Routes\RenderDonorWall;
 
 /**
  * Class Modules
  * @package GiveDivi\Divi\Helpers
  */
 class Modules {
-	public static function getModules() {
+	/**
+	 * List of Divi modules with corresponding routes
+	 *
+	 * @return \string[][]
+	 */
+	public static function config() {
 		return [
-			DonationFormModule::class,
-			DonorWallModule::class,
+			[
+				'module' => DonationFormModule::class,
+				'route'  => RenderDonationForm::class,
+			],
+			[
+				'module' => DonorWallModule::class,
+				'route'  => RenderDonorWall::class,
+			],
 		];
+	}
+
+	/**
+	 * Get Modules
+	 *
+	 * @return array
+	 */
+	public static function getModules() {
+		return array_map(
+			function( $module ) {
+				return $module['module'];
+			},
+			static::config()
+		);
+	}
+
+
+	/**
+	 * Get Routes
+	 *
+	 * @return array
+	 */
+	public static function getRoutes() {
+		return array_map(
+			function( $module ) {
+				return $module['route'];
+			},
+			static::config()
+		);
 	}
 }

--- a/src/Divi/Modules/DonationForm/Module.php
+++ b/src/Divi/Modules/DonationForm/Module.php
@@ -2,16 +2,35 @@
 
 namespace GiveDivi\Divi\Modules\DonationForm;
 
+use GiveDivi\Divi\Repositories\Forms;
+
 class Module extends \ET_Builder_Module {
 
-	public $slug       = 'give_donation_form';
-	public $vb_support = 'on';
+	public $slug;
+	public $vb_support;
 
 	protected $module_credits = [
 		'module_uri' => '',
 		'author'     => 'GiveWp',
 		'author_uri' => 'https://givewp.com',
 	];
+	/**
+	 * @var Forms
+	 */
+	private $forms;
+
+	/**
+	 * Module constructor.
+	 *
+	 * @param  Forms  $forms
+	 */
+	public function __construct( Forms $forms ) {
+		$this->forms      = $forms;
+		$this->slug       = 'give_donation_form';
+		$this->vb_support = 'on';
+
+		parent::__construct();
+	}
 
 	public function init() {
 		$this->name = esc_html__( 'Give Donation Form', 'give-divi' );
@@ -33,7 +52,7 @@ class Module extends \ET_Builder_Module {
 	 * @return array[]
 	 */
 	public function get_fields() {
-		$donationForms     = $this->getDonationForms();
+		$donationForms     = $this->forms->getAll();
 		$donationFormsKeys = array_map( 'strval', array_keys( $donationForms ) ); // Divi builder module requires array values to be a string
 
 		return [
@@ -47,7 +66,7 @@ class Module extends \ET_Builder_Module {
 				'label'           => esc_html__( 'Donation form format', 'give-divi' ),
 				'type'            => 'select',
 				'option_category' => 'basic_option',
-				'options'         => $this->getDonationFormFormats(),
+				'options'         => $this->forms->getFormFormats(),
 				'default'         => 'onpage',
 				'show_if'         => [
 					'id' => $donationFormsKeys,
@@ -101,43 +120,4 @@ class Module extends \ET_Builder_Module {
 		return give_form_shortcode( $atts );
 	}
 
-	/**
-	 * Get donation forms
-	 *
-	 * @return array
-	 * @since 1.0.0
-	 */
-	private function getDonationForms() {
-		$forms = [];
-
-		$forms_query = new \Give_Forms_Query(
-			[
-				'number'      => - 1,
-				'post_status' => 'publish',
-			]
-		);
-
-		$result = $forms_query->get_forms();
-
-		foreach ( $result as $form ) {
-			$forms[ $form->ID ] = $form->post_title;
-		}
-
-		return $forms;
-	}
-
-	/**
-	 * Get Donation form formats
-	 *
-	 * @return array
-	 * @since 1.0.0
-	 */
-	private function getDonationFormFormats() {
-		return [
-			'onpage' => esc_html__( 'Full form', 'give-divi' ),
-			'modal'  => esc_html__( 'Modal', 'give-divi' ),
-			'reveal' => esc_html__( 'Reveal', 'give-divi' ),
-			'button' => esc_html__( 'One Button Launch', 'give-divi' ),
-		];
-	}
 }

--- a/src/Divi/Modules/FormGoal/Module.php
+++ b/src/Divi/Modules/FormGoal/Module.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace GiveDivi\Divi\Modules\FormGoal;
+
+use GiveDivi\Divi\Repositories\Forms;
+
+class Module extends \ET_Builder_Module {
+	/**
+	 * @var string
+	 */
+	public $slug;
+
+	/**
+	 * @var string
+	 */
+	public $vb_support;
+
+	/**
+	 * @var string[]
+	 */
+	protected $module_credits;
+
+	/**
+	 * @var Forms
+	 */
+	private $forms;
+
+	/**
+	 * Module constructor.
+	 *
+	 * @param  Forms  $forms
+	 */
+	public function __construct( Forms $forms ) {
+		$this->forms          = $forms;
+		$this->slug           = 'give_form_goal';
+		$this->vb_support     = 'on';
+		$this->module_credits = [
+			'module_uri' => '',
+			'author'     => 'GiveWp',
+			'author_uri' => 'https://givewp.com',
+		];
+
+		parent::__construct();
+	}
+
+	public function init() {
+		$this->name = esc_html__( 'Give Form Goal', 'give-divi' );
+	}
+
+	/**
+	 * Get module fields
+	 *
+	 * @return array[]
+	 */
+	public function get_fields() {
+		$donationForms     = $this->forms->getAll();
+		$donationFormsKeys = array_map( 'strval', array_keys( $donationForms ) );
+
+		return [
+			'id'   => [
+				'label'           => esc_html__( 'Select Donation form', 'give-divi' ),
+				'type'            => 'select',
+				'option_category' => 'basic_option',
+				'options'         => [ esc_html__( 'Select form', 'give-divi' ) ] + $donationForms,
+			],
+			'text' => [
+				'label'           => esc_html__( 'Show text', 'give-divi' ),
+				'type'            => 'yes_no_button',
+				'option_category' => 'basic_option',
+				'options'         => [ 'off', 'on' ],
+				'default'         => 'on',
+				'show_if'         => [
+					'id' => $donationFormsKeys,
+				],
+			],
+			'bar'  => [
+				'label'           => esc_html__( 'Show bar', 'give-divi' ),
+				'type'            => 'yes_no_button',
+				'option_category' => 'basic_option',
+				'options'         => [ 'off', 'on' ],
+				'default'         => 'on',
+				'show_if'         => [
+					'id' => $donationFormsKeys,
+				],
+			],
+		];
+	}
+
+	/**
+	 * Render form goal
+	 *
+	 * @param  array  $attrs
+	 * @param  null  $content
+	 * @param  string  $render_slug
+	 *
+	 * @return string
+	 * @since 1.0.0
+	 */
+	public function render( $attrs, $content = null, $render_slug ) {
+		$attributes = [
+			'id'        => $attrs['id'],
+			'show_text' => isset( $attrs['text'] ) ? filter_var( $attrs['text'], FILTER_VALIDATE_BOOLEAN ) : true,
+			'show_bar'  => isset( $attrs['bar'] ) ? filter_var( $attrs['bar'], FILTER_VALIDATE_BOOLEAN ) : true,
+		];
+
+		return give_goal_shortcode( $attributes );
+	}
+}

--- a/src/Divi/Modules/FormGoal/index.js
+++ b/src/Divi/Modules/FormGoal/index.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import API, { CancelToken } from '../../resources/js/api';
+import parse from 'html-react-parser';
+
+export default class DonorWall extends React.Component {
+	static slug = 'give_form_goal';
+
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			fetching: false,
+			content: null,
+		};
+	}
+
+	getSnapshotBeforeUpdate( prevProps ) {
+		if (
+			prevProps.id !== this.props.id ||
+			prevProps.text !== this.props.text ||
+			prevProps.bar !== this.props.bar
+		) {
+			return true;
+		}
+
+		return null;
+	}
+
+	componentDidMount() {
+		if ( this.props.id ) {
+			this.fetchFormGoal();
+		}
+	}
+
+	componentDidUpdate( prevProps, prevState, snapshot ) {
+		if ( snapshot && ! this.state.fetching ) {
+			this.fetchFormGoal();
+		}
+	}
+
+	fetchFormGoal() {
+		this.setState(
+			{
+				fetching: true,
+			}
+		);
+
+		const params = {
+			id: this.props.id,
+			text: this.props.text === 'on',
+			bar: this.props.bar === 'on',
+		};
+
+		API.post( '/render-form-goal', params, { cancelToken: CancelToken.token } )
+			.then( ( response ) => {
+				this.setState( {
+					fetching: false,
+					content: response.data.content,
+				} );
+			} )
+			.catch( () => {
+				CancelToken.cancel();
+				this.setState( {
+					fetching: false,
+					content: '',
+				} );
+			} );
+	}
+
+	render() {
+		return (
+			<>{ this.state.content && parse( this.state.content ) }</>
+		);
+	}
+}

--- a/src/Divi/Repositories/Forms.php
+++ b/src/Divi/Repositories/Forms.php
@@ -1,0 +1,48 @@
+<?php
+namespace GiveDivi\Divi\Repositories;
+
+/**
+ * Class Forms
+ * @package GiveDivi\Divi\Repositories
+ */
+class Forms {
+	/**
+	 * Get all donation forms
+	 *
+	 * @return array
+	 * @since 1.0.0
+	 */
+	public function getAll() {
+		$forms = [];
+
+		$forms_query = new \Give_Forms_Query(
+			[
+				'number'      => - 1,
+				'post_status' => 'publish',
+			]
+		);
+
+		$result = $forms_query->get_forms();
+
+		foreach ( $result as $form ) {
+			$forms[ $form->ID ] = $form->post_title;
+		}
+
+		return $forms;
+	}
+
+	/**
+	 * Get Donation form formats
+	 *
+	 * @return array
+	 * @since 1.0.0
+	 */
+	public function getFormFormats() {
+		return [
+			'onpage' => esc_html__( 'Full form', 'give-divi' ),
+			'modal'  => esc_html__( 'Modal', 'give-divi' ),
+			'reveal' => esc_html__( 'Reveal', 'give-divi' ),
+			'button' => esc_html__( 'One Button Launch', 'give-divi' ),
+		];
+	}
+}

--- a/src/Divi/Routes/RenderFormGoal.php
+++ b/src/Divi/Routes/RenderFormGoal.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace GiveDivi\Divi\Routes;
+
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Class RenderFormGoal
+ * @package GiveDivi\Divi\Routes
+ */
+class RenderFormGoal extends Endpoint {
+
+	/** @var string */
+	protected $endpoint = 'give-divi/render-form-goal';
+
+
+	/**
+	 * @inheritDoc
+	 */
+	public function registerRoute() {
+		register_rest_route(
+			'give-api/v2',
+			$this->endpoint,
+			[
+				[
+					'methods'             => 'POST',
+					'callback'            => [ $this, 'handleRequest' ],
+					'permission_callback' => [ $this, 'permissionsCheck' ],
+					'args'                => [
+						'id'        => [
+							'type'     => 'integer',
+							'required' => true,
+						],
+						'show_text' => [
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => true,
+						],
+						'show_bar'  => [
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => true,
+						],
+
+					],
+				],
+				'schema' => [ $this, 'getSchema' ],
+			]
+		);
+	}
+
+	/**
+	 * @return array
+	 * @since 1.0.0
+	 */
+	public function getSchema() {
+		return [
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'give-divi',
+			'type'       => 'object',
+			'properties' => [
+				'id'        => [
+					'type'        => 'integer',
+					'description' => esc_html__( 'Donation Form id', 'give-divi' ),
+				],
+				'show_text' => [
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Show Goal Text', 'give-divi' ),
+				],
+				'show_bar'  => [
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Show Goal Bar', 'give-divi' ),
+				],
+			],
+		];
+	}
+
+	/**
+	 * @param  WP_REST_Request  $request
+	 *
+	 * @return WP_REST_Response
+	 * @since 1.0.0
+	 */
+	public function handleRequest( WP_REST_Request $request ) {
+		$attributes = [
+			'id'        => $request->get_param( 'id' ),
+			'show_text' => $request->get_param( 'show_text' ),
+			'show_bar'  => $request->get_param( 'show_bar' ),
+		];
+
+		return new WP_REST_Response(
+			[
+				'status'  => true,
+				'content' => give_goal_shortcode( $attributes ),
+			]
+		);
+	}
+
+}

--- a/src/Divi/resources/js/give-divi.js
+++ b/src/Divi/resources/js/give-divi.js
@@ -3,7 +3,8 @@ import $ from 'jquery';
 
 import DonationForm from '../../Modules/DonationForm';
 import DonorWall from '../../Modules/DonorWall';
+import FormGoal from '../../Modules/FormGoal';
 
 $( window ).on( 'et_builder_api_ready', ( event, API ) => {
-	API.registerModules( [ DonationForm, DonorWall ] );
+	API.registerModules( [ DonationForm, DonorWall, FormGoal ] );
 } );


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->
Please resolve #9 before this one to avoid merge conflicts.

Resolves #6

## Description

This PR adds support for the Donation Form Goal shortcode to be used as a Divi module. 

## Affects

Creates a new Donation Form Goal Divi module.


<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

![image](https://user-images.githubusercontent.com/4222590/104952612-20e15600-59c5-11eb-9119-26013008cee2.png)

<!-- Include screenshots or video to better communicate your changes. -->

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

1. Add a new page using Divi editor
2. Try to insert the Give Form Goal module
