### PR TITLE
Add Donor Login Form module

### DIFF
--- a/src/Divi/Helpers/Modules.php
+++ b/src/Divi/Helpers/Modules.php
@@ -6,10 +6,12 @@ namespace GiveDivi\Divi\Helpers;
 use GiveDivi\Divi\Modules\DonationForm\Module as DonationFormModule;
 use GiveDivi\Divi\Modules\DonorWall\Module as DonorWallModule;
 use GiveDivi\Divi\Modules\FormGoal\Module as FormGoalModule;
+use GiveDivi\Divi\Modules\LoginForm\Module as LoginFormModule;
 // Module routes Routes
 use GiveDivi\Divi\Routes\RenderDonationForm;
 use GiveDivi\Divi\Routes\RenderDonorWall;
 use GiveDivi\Divi\Routes\RenderFormGoal;
+use GiveDivi\Divi\Routes\RenderLoginForm;
 
 /**
  * Class Modules
@@ -34,6 +36,10 @@ class Modules {
 			[
 				'module' => FormGoalModule::class,
 				'route'  => RenderFormGoal::class,
+			],
+			[
+				'module' => LoginFormModule::class,
+				'route'  => RenderLoginForm::class,
 			],
 		];
 	}

--- a/src/Divi/Modules/LoginForm/Module.php
+++ b/src/Divi/Modules/LoginForm/Module.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace GiveDivi\Divi\Modules\LoginForm;
+
+use GiveDivi\Divi\Repositories\Forms;
+
+class Module extends \ET_Builder_Module {
+	/**
+	 * @var string
+	 */
+	public $slug;
+
+	/**
+	 * @var string
+	 */
+	public $vb_support;
+
+	/**
+	 * @var string[]
+	 */
+	protected $module_credits;
+
+	/**
+	 * @var Forms
+	 */
+	private $forms;
+
+	/**
+	 * Module constructor.
+	 *
+	 * @param  Forms  $forms
+	 */
+	public function __construct( Forms $forms ) {
+		$this->forms          = $forms;
+		$this->slug           = 'give_login_form';
+		$this->vb_support     = 'on';
+		$this->module_credits = [
+			'module_uri' => '',
+			'author'     => 'GiveWp',
+			'author_uri' => 'https://givewp.com',
+		];
+
+		parent::__construct();
+	}
+
+	public function init() {
+		$this->name = esc_html__( 'Give Login Form', 'give-divi' );
+	}
+
+	/**
+	 * Get module fields
+	 *
+	 * @return array[]
+	 */
+	public function get_fields() {
+		return [
+			'redirect' => [
+				'label'           => esc_html__( 'Redirect', 'give-divi' ),
+				'type'            => 'yes_no_button',
+				'option_category' => 'basic_option',
+				'options'         => [ 'off', 'on' ],
+				'default'         => 'off',
+			],
+			'login'    => [
+				'label'           => esc_html__( 'Login Redirect URL', 'give-divi' ),
+				'type'            => 'text',
+				'option_category' => 'basic_option',
+				'default'         => '',
+				'show_if'         => [
+					'redirect' => 'on',
+				],
+			],
+			'logout'   => [
+				'label'           => esc_html__( 'Logout Redirect URL', 'give-divi' ),
+				'type'            => 'text',
+				'option_category' => 'basic_option',
+				'default'         => '',
+				'show_if'         => [
+					'redirect' => 'on',
+				],
+			],
+		];
+	}
+
+	/**
+	 * Render Login form
+	 *
+	 * @param  array  $attrs
+	 * @param  null  $content
+	 * @param  string  $render_slug
+	 *
+	 * @return string
+	 * @since 1.0.0
+	 */
+	public function render( $attrs, $content = null, $render_slug ) {
+		$attributes = [
+			'redirect'        => isset( $attrs['redirect'] ) ? filter_var( $attrs['redirect'], FILTER_VALIDATE_BOOLEAN ) : false,
+			'login-redirect'  => isset( $attrs['login'] ) ? esc_url( $attrs['login'] ) : '',
+			'logout-redirect' => isset( $attrs['logout'] ) ? esc_url( $attrs['logout'] ) : '',
+		];
+
+		return give_login_form_shortcode( $attributes );
+	}
+}

--- a/src/Divi/Modules/LoginForm/Module.php
+++ b/src/Divi/Modules/LoginForm/Module.php
@@ -2,8 +2,6 @@
 
 namespace GiveDivi\Divi\Modules\LoginForm;
 
-use GiveDivi\Divi\Repositories\Forms;
-
 class Module extends \ET_Builder_Module {
 	/**
 	 * @var string
@@ -21,17 +19,9 @@ class Module extends \ET_Builder_Module {
 	protected $module_credits;
 
 	/**
-	 * @var Forms
-	 */
-	private $forms;
-
-	/**
 	 * Module constructor.
-	 *
-	 * @param  Forms  $forms
 	 */
-	public function __construct( Forms $forms ) {
-		$this->forms          = $forms;
+	public function __construct() {
 		$this->slug           = 'give_login_form';
 		$this->vb_support     = 'on';
 		$this->module_credits = [

--- a/src/Divi/Modules/LoginForm/index.js
+++ b/src/Divi/Modules/LoginForm/index.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import API, { CancelToken } from '../../resources/js/api';
+import parse from 'html-react-parser';
+
+export default class LoginForm extends React.Component {
+	static slug = 'give_login_form';
+
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			fetching: false,
+			content: null,
+		};
+	}
+
+	getSnapshotBeforeUpdate( prevProps ) {
+		if (
+			prevProps.redirect !== this.props.redirect ||
+			prevProps.login !== this.props.login ||
+			prevProps.logout !== this.props.logout
+		) {
+			return true;
+		}
+
+		return null;
+	}
+
+	componentDidMount() {
+		this.fetchLoginForm();
+	}
+
+	componentDidUpdate( prevProps, prevState, snapshot ) {
+		if ( snapshot && ! this.state.fetching ) {
+			this.fetchLoginForm();
+		}
+	}
+
+	fetchLoginForm() {
+		this.setState(
+			{
+				fetching: true,
+			}
+		);
+
+		const params = {
+			redirect: this.props.redirect === 'on',
+			login: this.props.login,
+			logout: this.props.logout,
+		};
+
+		API.post( '/render-login-form', params, { cancelToken: CancelToken.token } )
+			.then( ( response ) => {
+				this.setState( {
+					fetching: false,
+					content: response.data.content,
+				} );
+			} )
+			.catch( () => {
+				CancelToken.cancel();
+				this.setState( {
+					fetching: false,
+					content: '',
+				} );
+			} );
+	}
+
+	render() {
+		return (
+			<>{ this.state.content && parse( this.state.content ) }</>
+		);
+	}
+}

--- a/src/Divi/Routes/RenderLoginForm.php
+++ b/src/Divi/Routes/RenderLoginForm.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace GiveDivi\Divi\Routes;
+
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Class RenderFormGoal
+ * @package GiveDivi\Divi\Routes
+ */
+class RenderLoginForm extends Endpoint {
+
+	/** @var string */
+	protected $endpoint = 'give-divi/render-login-form';
+
+
+	/**
+	 * @inheritDoc
+	 */
+	public function registerRoute() {
+		register_rest_route(
+			'give-api/v2',
+			$this->endpoint,
+			[
+				[
+					'methods'             => 'POST',
+					'callback'            => [ $this, 'handleRequest' ],
+					'permission_callback' => [ $this, 'permissionsCheck' ],
+					'args'                => [
+						'redirect' => [
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => false,
+						],
+						'login'    => [
+							'type'     => 'string',
+							'required' => false,
+							'default'  => '',
+						],
+						'logout'   => [
+							'type'     => 'string',
+							'required' => false,
+							'default'  => '',
+						],
+
+					],
+				],
+				'schema' => [ $this, 'getSchema' ],
+			]
+		);
+	}
+
+	/**
+	 * @return array
+	 * @since 1.0.0
+	 */
+	public function getSchema() {
+		return [
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'give-divi',
+			'type'       => 'object',
+			'properties' => [
+				'redirect' => [
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Enable Redirect', 'give-divi' ),
+				],
+				'login'    => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Login Redirect URL', 'give-divi' ),
+				],
+				'logout'   => [
+					'type'        => 'string',
+					'description' => esc_html__( 'logout Redirect URL', 'give-divi' ),
+				],
+			],
+		];
+	}
+
+	/**
+	 * @param  WP_REST_Request  $request
+	 *
+	 * @return WP_REST_Response
+	 * @since 1.0.0
+	 */
+	public function handleRequest( WP_REST_Request $request ) {
+		$attributes = [
+			'redirect'        => $request->get_param( 'redirect' ),
+			'login-redirect'  => $request->get_param( 'login' ),
+			'logout-redirect' => $request->get_param( 'logout' ),
+		];
+
+		return new WP_REST_Response(
+			[
+				'status'  => true,
+				'content' => give_login_form_shortcode( $attributes ),
+			]
+		);
+	}
+
+}

--- a/src/Divi/resources/js/give-divi.js
+++ b/src/Divi/resources/js/give-divi.js
@@ -4,7 +4,8 @@ import $ from 'jquery';
 import DonationForm from '../../Modules/DonationForm';
 import DonorWall from '../../Modules/DonorWall';
 import FormGoal from '../../Modules/FormGoal';
+import LoginForm from '../../Modules/LoginForm';
 
 $( window ).on( 'et_builder_api_ready', ( event, API ) => {
-	API.registerModules( [ DonationForm, DonorWall, FormGoal ] );
+	API.registerModules( [ DonationForm, DonorWall, FormGoal, LoginForm ] );
 } );


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #11 

## Description

This PR adds support for the Donor Login Form shortcode to be used as a Divi module.

## Affects

Adds new Donor Login Form Divi module.

## Visuals

<!-- Include screenshots or video to better communicate your changes. -->
![image](https://user-images.githubusercontent.com/4222590/105006160-8e799a80-5a36-11eb-92bd-a6cefad39410.png)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
1. Add a new page using Divi editor
2. Insert the Give Login Form module
3. Test module on the front-end

