### PR TITLE
Add Donor Registration Form module

### DIFF
--- a/src/Divi/Helpers/Modules.php
+++ b/src/Divi/Helpers/Modules.php
@@ -6,10 +6,12 @@ namespace GiveDivi\Divi\Helpers;
 use GiveDivi\Divi\Modules\DonationForm\Module as DonationFormModule;
 use GiveDivi\Divi\Modules\DonorWall\Module as DonorWallModule;
 use GiveDivi\Divi\Modules\FormGoal\Module as FormGoalModule;
+use GiveDivi\Divi\Modules\RegistrationForm\Module as RegistrationFormModule;
 // Module routes Routes
 use GiveDivi\Divi\Routes\RenderDonationForm;
 use GiveDivi\Divi\Routes\RenderDonorWall;
 use GiveDivi\Divi\Routes\RenderFormGoal;
+use GiveDivi\Divi\Routes\RenderRegistrationForm;
 
 /**
  * Class Modules
@@ -34,6 +36,10 @@ class Modules {
 			[
 				'module' => FormGoalModule::class,
 				'route'  => RenderFormGoal::class,
+			],
+			[
+				'module' => RegistrationFormModule::class,
+				'route'  => RenderRegistrationForm::class,
 			],
 		];
 	}

--- a/src/Divi/Modules/RegistrationForm/Module.php
+++ b/src/Divi/Modules/RegistrationForm/Module.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace GiveDivi\Divi\Modules\RegistrationForm;
+
+use GiveDivi\Divi\Repositories\Forms;
+
+class Module extends \ET_Builder_Module {
+	/**
+	 * @var string
+	 */
+	public $slug;
+
+	/**
+	 * @var string
+	 */
+	public $vb_support;
+
+	/**
+	 * @var string[]
+	 */
+	protected $module_credits;
+	/**
+	 * @var Forms
+	 */
+	private $forms;
+
+	/**
+	 * Module constructor.
+	 *
+	 * @param  Forms  $forms
+	 */
+	public function __construct( Forms $forms ) {
+		$this->forms          = $forms;
+		$this->slug           = 'give_registration_form';
+		$this->vb_support     = 'on';
+		$this->module_credits = [
+			'module_uri' => '',
+			'author'     => 'GiveWp',
+			'author_uri' => 'https://givewp.com',
+		];
+
+		parent::__construct();
+	}
+
+	public function init() {
+		$this->name = esc_html__( 'Give Registration Form', 'give-divi' );
+	}
+
+	/**
+	 * Get module fields
+	 *
+	 * @return array[]
+	 */
+	public function get_fields() {
+		return [
+			'active'   => [
+				'label'           => esc_html__( 'Redirect', 'give-divi' ),
+				'type'            => 'yes_no_button',
+				'option_category' => 'basic_option',
+				'options'         => [ 'off', 'on' ],
+				'default'         => 'off',
+			],
+			'redirect' => [
+				'label'           => esc_html__( 'Redirect URL', 'give-divi' ),
+				'type'            => 'text',
+				'option_category' => 'basic_option',
+				'default'         => '',
+				'show_if'         => [
+					'active' => 'on',
+				],
+			],
+		];
+	}
+
+	/**
+	 * Render Registration form
+	 *
+	 * @param  array  $attrs
+	 * @param  null  $content
+	 * @param  string  $render_slug
+	 *
+	 * @return string
+	 * @since 1.0.0
+	 */
+	public function render( $attrs, $content = null, $render_slug ) {
+		$redirect = ( isset( $attrs['active'], $attrs['redirect'] ) && boolval( $attrs['active'] ) )
+			? esc_url( $attrs['url'] )
+			: '';
+
+		return $this->forms->renderRegistrationForm( $redirect );
+	}
+}

--- a/src/Divi/Modules/RegistrationForm/index.js
+++ b/src/Divi/Modules/RegistrationForm/index.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import API, { CancelToken } from '../../resources/js/api';
+import parse from 'html-react-parser';
+
+export default class RegistrationForm extends React.Component {
+	static slug = 'give_registration_form';
+
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			fetching: false,
+			content: null,
+		};
+	}
+
+	getSnapshotBeforeUpdate( prevProps ) {
+		if (
+			prevProps.active !== this.props.active ||
+			prevProps.redirect !== this.props.redirect
+		) {
+			return true;
+		}
+
+		return null;
+	}
+
+	componentDidMount() {
+		this.fetchRegistrationForm();
+	}
+
+	componentDidUpdate( prevProps, prevState, snapshot ) {
+		if ( snapshot && ! this.state.fetching ) {
+			this.fetchRegistrationForm();
+		}
+	}
+
+	fetchRegistrationForm() {
+		this.setState(
+			{
+				fetching: true,
+			}
+		);
+
+		const params = {
+			active: this.props.active === 'on',
+			redirect: this.props.redirect,
+		};
+
+		API.post( '/render-registration-form', params, { cancelToken: CancelToken.token } )
+			.then( ( response ) => {
+				this.setState( {
+					fetching: false,
+					content: response.data.content,
+				} );
+			} )
+			.catch( () => {
+				CancelToken.cancel();
+				this.setState( {
+					fetching: false,
+					content: '',
+				} );
+			} );
+	}
+
+	render() {
+		return (
+			<>{ this.state.content && parse( this.state.content ) }</>
+		);
+	}
+}

--- a/src/Divi/Repositories/Forms.php
+++ b/src/Divi/Repositories/Forms.php
@@ -45,4 +45,29 @@ class Forms {
 			'button' => esc_html__( 'One Button Launch', 'give-divi' ),
 		];
 	}
+
+	/**
+	 * Render registration form
+	 * This method exist because the give_register_form function doesn't render the registration form if user is logged
+	 *
+	 * @param  string  $redirect
+	 *
+	 * @return string
+	 */
+	public function renderRegistrationForm( $redirect = '' ) {
+		if ( empty( $redirect ) ) {
+			$redirect = give_get_current_page_url();
+		}
+
+		ob_start();
+
+		give_get_template(
+			'shortcode-register',
+			[
+				'give_register_redirect' => $redirect,
+			]
+		);
+
+		return apply_filters( 'give_register_form', ob_get_clean() );
+	}
 }

--- a/src/Divi/Routes/RenderRegistrationForm.php
+++ b/src/Divi/Routes/RenderRegistrationForm.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace GiveDivi\Divi\Routes;
+
+use GiveDivi\Divi\Repositories\Forms;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Class RenderFormGoal
+ * @package GiveDivi\Divi\Routes
+ */
+class RenderRegistrationForm extends Endpoint {
+
+	/** @var string */
+	protected $endpoint = 'give-divi/render-registration-form';
+
+	/**
+	 * @var Forms
+	 */
+	private $forms;
+
+	/**
+	 * RenderRegistrationForm constructor.
+	 *
+	 * @param  Forms  $forms
+	 */
+	public function __construct( Forms $forms ) {
+		$this->forms = $forms;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function registerRoute() {
+		register_rest_route(
+			'give-api/v2',
+			$this->endpoint,
+			[
+				[
+					'methods'             => 'POST',
+					'callback'            => [ $this, 'handleRequest' ],
+					'permission_callback' => [ $this, 'permissionsCheck' ],
+					'args'                => [
+						'active'   => [
+							'type'     => 'boolean',
+							'required' => true,
+							'default'  => false,
+						],
+						'redirect' => [
+							'type'     => 'string',
+							'required' => false,
+							'default'  => '',
+						],
+					],
+				],
+				'schema' => [ $this, 'getSchema' ],
+			]
+		);
+	}
+
+	/**
+	 * @return array
+	 * @since 1.0.0
+	 */
+	public function getSchema() {
+		return [
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'give-divi',
+			'type'       => 'object',
+			'properties' => [
+				'url' => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Register Redirect URL', 'give-divi' ),
+				],
+			],
+		];
+	}
+
+	/**
+	 * @param  WP_REST_Request  $request
+	 *
+	 * @return WP_REST_Response
+	 * @since 1.0.0
+	 */
+	public function handleRequest( WP_REST_Request $request ) {
+		// Redirect url
+		$redirect = ( $request->get_param( 'active' ) && ! empty( $request->get_param( 'redirect' ) ) )
+			? $request->get_param( 'redirect' )
+			: '';
+
+		return new WP_REST_Response(
+			[
+				'status'  => true,
+				'content' => $this->forms->renderRegistrationForm( $redirect ),
+			]
+		);
+	}
+
+}

--- a/src/Divi/resources/js/give-divi.js
+++ b/src/Divi/resources/js/give-divi.js
@@ -4,7 +4,8 @@ import $ from 'jquery';
 import DonationForm from '../../Modules/DonationForm';
 import DonorWall from '../../Modules/DonorWall';
 import FormGoal from '../../Modules/FormGoal';
+import RegistrationForm from '../../Modules/RegistrationForm';
 
 $( window ).on( 'et_builder_api_ready', ( event, API ) => {
-	API.registerModules( [ DonationForm, DonorWall, FormGoal ] );
+	API.registerModules( [ DonationForm, DonorWall, FormGoal, RegistrationForm ] );
 } );


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #13 

## Description

This PR adds support for the Donor Registration Form shortcode to be used as a Divi module.

## Affects

Adds new Donor Registration Form Divi module.

## Visuals

![image](https://user-images.githubusercontent.com/4222590/105017117-b6bbc600-5a43-11eb-81b9-a0ec573f8ed9.png)


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
1. Add a new page using Divi editor
2. Insert the Give Registration Form module
3. Test module on the front-end
