### PR TITLE
Add Donation Receipt module

### DIFF
--- a/src/Divi/Helpers/Modules.php
+++ b/src/Divi/Helpers/Modules.php
@@ -6,10 +6,12 @@ namespace GiveDivi\Divi\Helpers;
 use GiveDivi\Divi\Modules\DonationForm\Module as DonationFormModule;
 use GiveDivi\Divi\Modules\DonorWall\Module as DonorWallModule;
 use GiveDivi\Divi\Modules\FormGoal\Module as FormGoalModule;
+use GiveDivi\Divi\Modules\DonationReceipt\Module as DonationReceiptModule;
 // Module routes Routes
 use GiveDivi\Divi\Routes\RenderDonationForm;
 use GiveDivi\Divi\Routes\RenderDonorWall;
 use GiveDivi\Divi\Routes\RenderFormGoal;
+use GiveDivi\Divi\Routes\RenderDonationReceipt;
 
 /**
  * Class Modules
@@ -34,6 +36,10 @@ class Modules {
 			[
 				'module' => FormGoalModule::class,
 				'route'  => RenderFormGoal::class,
+			],
+			[
+				'module' => DonationReceiptModule::class,
+				'route'  => RenderDonationReceipt::class,
 			],
 		];
 	}

--- a/src/Divi/Modules/DonationReceipt/Module.php
+++ b/src/Divi/Modules/DonationReceipt/Module.php
@@ -45,6 +45,15 @@ class Module extends \ET_Builder_Module {
 	 */
 	public function get_fields() {
 		return [
+			'donation_id'    => [
+				'label'           => 'Donation ID',
+				'type'            => 'text',
+				'option_category' => 'basic_option',
+				'default'         => $this->donation->getLastDonationId( get_current_user_id() ),
+				'show_if'         => [
+					'donor' => 'none', // always hidden
+				],
+			],
 			'donor'          => [
 				'label'           => esc_html__( 'Display donor', 'give-divi' ),
 				'type'            => 'yes_no_button',
@@ -133,7 +142,7 @@ class Module extends \ET_Builder_Module {
 			'error'          => isset( $attrs['error'] ) ? esc_attr( $attrs['error'] ) : '',
 		];
 
-		return $this->donation->getReceiptPreview( $attributes );
+		return  give_receipt_shortcode( $attributes );
 	}
 
 }

--- a/src/Divi/Modules/DonationReceipt/Module.php
+++ b/src/Divi/Modules/DonationReceipt/Module.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace GiveDivi\Divi\Modules\DonationReceipt;
+
+use GiveDivi\Divi\Repositories\Donation;
+
+class Module extends \ET_Builder_Module {
+
+	public $slug;
+	public $vb_support;
+
+	protected $module_credits;
+
+	/**
+	 * @var Donation
+	 */
+	private $donation;
+
+	/**
+	 * Module constructor.
+	 *
+	 * @param  Donation  $donation
+	 */
+	public function __construct( Donation $donation ) {
+		$this->donation       = $donation;
+		$this->slug           = 'give_donation_receipt';
+		$this->vb_support     = 'on';
+		$this->module_credits = [
+			'module_uri' => '',
+			'author'     => 'GiveWp',
+			'author_uri' => 'https://givewp.com',
+		];
+
+		parent::__construct();
+	}
+
+	public function init() {
+		$this->name = esc_html__( 'Give Donation Receipt', 'give-divi' );
+	}
+
+	/**
+	 * Get module fields
+	 *
+	 * @return array[]
+	 */
+	public function get_fields() {
+		return [
+			'donor'          => [
+				'label'           => esc_html__( 'Display donor', 'give-divi' ),
+				'type'            => 'yes_no_button',
+				'option_category' => 'basic_option',
+				'options'         => [ 'off', 'on' ],
+				'default'         => 'on',
+			],
+			'price'          => [
+				'label'           => esc_html__( 'Display total', 'give-divi' ),
+				'type'            => 'yes_no_button',
+				'option_category' => 'basic_option',
+				'options'         => [ 'off', 'on' ],
+				'default'         => 'on',
+			],
+			'date'           => [
+				'label'           => esc_html__( 'Display date', 'give-divi' ),
+				'type'            => 'yes_no_button',
+				'option_category' => 'basic_option',
+				'options'         => [ 'off', 'on' ],
+				'default'         => 'on',
+			],
+			'payment_method' => [
+				'label'           => esc_html__( 'Display payment method', 'give-divi' ),
+				'type'            => 'yes_no_button',
+				'option_category' => 'basic_option',
+				'options'         => [ 'off', 'on' ],
+				'default'         => 'on',
+			],
+			'payment_id'     => [
+				'label'           => esc_html__( 'Display payment method', 'give-divi' ),
+				'type'            => 'yes_no_button',
+				'option_category' => 'basic_option',
+				'options'         => [ 'off', 'on' ],
+				'default'         => 'on',
+			],
+			'payment_status' => [
+				'label'           => esc_html__( 'Display payment status', 'give-divi' ),
+				'type'            => 'yes_no_button',
+				'option_category' => 'basic_option',
+				'options'         => [ 'off', 'on' ],
+				'default'         => 'off',
+			],
+			'company_name'   => [
+				'label'           => esc_html__( 'Display company name', 'give-divi' ),
+				'type'            => 'yes_no_button',
+				'option_category' => 'basic_option',
+				'options'         => [ 'off', 'on' ],
+				'default'         => 'off',
+			],
+			'status_notice'  => [
+				'label'           => esc_html__( 'Display status notice', 'give-divi' ),
+				'type'            => 'yes_no_button',
+				'option_category' => 'basic_option',
+				'options'         => [ 'off', 'on' ],
+				'default'         => 'on',
+			],
+			'error'          => [
+				'label'           => esc_html__( 'Error notice text', 'give-divi' ),
+				'type'            => 'text',
+				'option_category' => 'basic_option',
+				'default'         => esc_html__( 'You are missing the donation id to view this donation receipt.', 'give-divi' ),
+			],
+		];
+	}
+
+	/**
+	 * Render donation form
+	 *
+	 * @param  array  $attrs
+	 * @param  null  $content
+	 * @param  string  $render_slug
+	 *
+	 * @return string|void
+	 * @since 1.0.0
+	 */
+	public function render( $attrs, $content = null, $render_slug ) {
+		$attributes = [
+			'donor'          => isset( $attrs['donor'] ) ? filter_var( $attrs['donor'], FILTER_VALIDATE_BOOLEAN ) : true,
+			'price'          => isset( $attrs['price'] ) ? filter_var( $attrs['price'], FILTER_VALIDATE_BOOLEAN ) : true,
+			'date'           => isset( $attrs['date'] ) ? filter_var( $attrs['date'], FILTER_VALIDATE_BOOLEAN ) : true,
+			'payment_method' => isset( $attrs['payment_method'] ) ? filter_var( $attrs['payment_method'], FILTER_VALIDATE_BOOLEAN ) : true,
+			'payment_id'     => isset( $attrs['payment_id'] ) ? filter_var( $attrs['payment_id'], FILTER_VALIDATE_BOOLEAN ) : true,
+			'payment_status' => isset( $attrs['payment_status'] ) ? filter_var( $attrs['payment_status'], FILTER_VALIDATE_BOOLEAN ) : false,
+			'company_name'   => isset( $attrs['company_name'] ) ? filter_var( $attrs['company_name'], FILTER_VALIDATE_BOOLEAN ) : false,
+			'status_notice'  => isset( $attrs['status_notice'] ) ? filter_var( $attrs['status_notice'], FILTER_VALIDATE_BOOLEAN ) : true,
+			'error'          => isset( $attrs['error'] ) ? esc_attr( $attrs['error'] ) : '',
+		];
+
+		return $this->donation->getReceiptPreview( $attributes );
+	}
+
+}

--- a/src/Divi/Modules/DonationReceipt/index.js
+++ b/src/Divi/Modules/DonationReceipt/index.js
@@ -63,7 +63,7 @@ export default class DonationReceipt extends React.Component {
 			error: this.props.error,
 		};
 
-		API.post( '/render-donation-receipt', params, { cancelToken: CancelToken.token } )
+		API.post( `/render-donation-receipt&donation_id=${ this.props.donation_id }`, params, { cancelToken: CancelToken.token } )
 			.then( ( response ) => {
 				this.setState( {
 					fetching: false,

--- a/src/Divi/Modules/DonationReceipt/index.js
+++ b/src/Divi/Modules/DonationReceipt/index.js
@@ -1,0 +1,87 @@
+// External Dependencies
+import React from 'react';
+import API, { CancelToken } from '../../resources/js/api';
+import parse from 'html-react-parser';
+
+export default class DonationReceipt extends React.Component {
+	static slug = 'give_donation_receipt';
+
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			fetching: false,
+			content: null,
+		};
+	}
+
+	getSnapshotBeforeUpdate( prevProps ) {
+		if (
+			prevProps.donor !== this.props.donor ||
+			prevProps.price !== this.props.price ||
+			prevProps.date !== this.props.date ||
+			prevProps.date !== this.props.date ||
+			prevProps.payment_method !== this.props.payment_method ||
+			prevProps.payment_id !== this.props.payment_id ||
+			prevProps.payment_status !== this.props.payment_status ||
+			prevProps.company_name !== this.props.company_name ||
+			prevProps.status_notice !== this.props.status_notice ||
+			prevProps.error !== this.props.error
+		) {
+			return true;
+		}
+
+		return null;
+	}
+
+	componentDidMount() {
+		this.fetchDonationReceipt();
+	}
+
+	componentDidUpdate( prevProps, prevState, snapshot ) {
+		if ( snapshot && ! this.state.fetching ) {
+			this.fetchDonationReceipt();
+		}
+	}
+
+	fetchDonationReceipt() {
+		this.setState(
+			{
+				fetching: true,
+			}
+		);
+
+		const params = {
+			donor: this.props.donor === 'on',
+			price: this.props.price === 'on',
+			date: this.props.date === 'on',
+			payment_method: this.props.payment_method === 'on',
+			payment_id: this.props.payment_id === 'on',
+			payment_status: this.props.payment_status === 'on',
+			company_name: this.props.company_name === 'on',
+			status_notice: this.props.status_notice === 'on',
+			error: this.props.error,
+		};
+
+		API.post( '/render-donation-receipt', params, { cancelToken: CancelToken.token } )
+			.then( ( response ) => {
+				this.setState( {
+					fetching: false,
+					content: response.data.content,
+				} );
+			} )
+			.catch( () => {
+				CancelToken.cancel();
+				this.setState( {
+					fetching: false,
+					content: '',
+				} );
+			} );
+	}
+
+	render() {
+		return (
+			<>{ this.state.content && parse( this.state.content ) }</>
+		);
+	}
+}

--- a/src/Divi/Modules/DonationReceipt/index.js
+++ b/src/Divi/Modules/DonationReceipt/index.js
@@ -63,7 +63,7 @@ export default class DonationReceipt extends React.Component {
 			error: this.props.error,
 		};
 
-		API.post( `/render-donation-receipt&donation_id=${ this.props.donation_id }`, params, { cancelToken: CancelToken.token } )
+		API.post( `/render-donation-receipt?donation_id=${ this.props.donation_id }`, params, { cancelToken: CancelToken.token } )
 			.then( ( response ) => {
 				this.setState( {
 					fetching: false,

--- a/src/Divi/Repositories/Donation.php
+++ b/src/Divi/Repositories/Donation.php
@@ -1,0 +1,46 @@
+<?php
+namespace GiveDivi\Divi\Repositories;
+
+/**
+ * Class Donation
+ * @package GiveDivi\Divi\Repositories
+ */
+class Donation {
+
+	/**
+	 * Get last donation id from the revenue table
+	 * @return int
+	 */
+	public function getLastDonationId() {
+		global $wpdb;
+
+		return $wpdb->get_var(
+			"
+			SELECT donation_id 
+			FROM {$wpdb->prefix}give_revenue
+			ORDER BY donation_id DESC 
+			LIMIT 1
+			"
+		);
+
+	}
+
+	/**
+	 * Get donation receipt preview
+	 *
+	 * @param array $attributes
+	 *
+	 * @return string
+	 * @since 1.0.0
+	 */
+	public function getReceiptPreview( $attributes ) {
+		global $give_receipt_args, $donation;
+
+		$donation          = $this->getLastDonationId();
+		$give_receipt_args = $attributes;
+
+		ob_start();
+		give_get_template_part( 'shortcode', 'receipt' );
+		return ob_get_clean();
+	}
+}

--- a/src/Divi/Repositories/Donation.php
+++ b/src/Divi/Repositories/Donation.php
@@ -8,39 +8,30 @@ namespace GiveDivi\Divi\Repositories;
 class Donation {
 
 	/**
-	 * Get last donation id from the revenue table
+	 * Get Donor's last donation id
+	 *
+	 * @param int $donorId
+	 *
 	 * @return int
 	 */
-	public function getLastDonationId() {
-		global $wpdb;
+	public function getLastDonationId( $donorId ) {
+		if ( ! $donorId ) {
+			return 0;
+		}
 
-		return $wpdb->get_var(
-			"
-			SELECT donation_id 
-			FROM {$wpdb->prefix}give_revenue
-			ORDER BY donation_id DESC 
-			LIMIT 1
-			"
+		$post = get_posts(
+			[
+				'post_type'   => 'give_payment',
+				'post_status' => 'publish',
+				'author'      => $donorId,
+				'numberposts' => 1,
+			]
 		);
 
-	}
+		if ( empty( $post ) ) {
+			return 0;
+		}
 
-	/**
-	 * Get donation receipt preview
-	 *
-	 * @param array $attributes
-	 *
-	 * @return string
-	 * @since 1.0.0
-	 */
-	public function getReceiptPreview( $attributes ) {
-		global $give_receipt_args, $donation;
-
-		$donation          = $this->getLastDonationId();
-		$give_receipt_args = $attributes;
-
-		ob_start();
-		give_get_template_part( 'shortcode', 'receipt' );
-		return ob_get_clean();
+		return $post[0]->ID;
 	}
 }

--- a/src/Divi/Routes/RenderDonationReceipt.php
+++ b/src/Divi/Routes/RenderDonationReceipt.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace GiveDivi\Divi\Routes;
+
+use GiveDivi\Divi\Repositories\Donation;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Class RenderDonationReceipt
+ * @package GiveDivi\Divi\Routes
+ */
+class RenderDonationReceipt extends Endpoint {
+
+	/** @var string */
+	protected $endpoint = 'give-divi/render-donation-receipt';
+
+	/**
+	 * @var Donation
+	 */
+	private $donation;
+
+	/**
+	 * RenderDonationReceipt constructor.
+	 *
+	 * @param  Donation  $donation
+	 */
+	public function __construct( Donation $donation ) {
+		$this->donation = $donation;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function registerRoute() {
+		register_rest_route(
+			'give-api/v2',
+			$this->endpoint,
+			[
+				[
+					'methods'             => 'POST',
+					'callback'            => [ $this, 'handleRequest' ],
+					'permission_callback' => [ $this, 'permissionsCheck' ],
+					'args'                => [
+						'donor'          => [
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => true,
+						],
+						'price'          => [
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => true,
+						],
+						'date'           => [
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => true,
+						],
+						'payment_method' => [
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => true,
+						],
+						'payment_id'     => [
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => true,
+						],
+						'payment_status' => [
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => false,
+						],
+						'company_name'   => [
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => false,
+						],
+						'status_notice'  => [
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => true,
+						],
+						'error'          => [
+							'type'     => 'string',
+							'required' => false,
+							'default'  => esc_html__( 'You are missing the donation id to view this donation receipt.', 'give-divi' ),
+						],
+					],
+				],
+				'schema' => [ $this, 'getSchema' ],
+			]
+		);
+	}
+
+	/**
+	 * @return array
+	 * @since 1.0.0
+	 */
+	public function getSchema() {
+		return [
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'give-divi',
+			'type'       => 'object',
+			'properties' => [
+				'donor'          => [
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Display donor', 'give-divi' ),
+				],
+				'price'          => [
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Display total', 'give-divi' ),
+				],
+				'date'           => [
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Display date', 'give-divi' ),
+				],
+				'payment_method' => [
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Display payment method', 'give-divi' ),
+				],
+				'payment_id'     => [
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Display payment id', 'give-divi' ),
+				],
+				'payment_status' => [
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Display payment status', 'give-divi' ),
+				],
+				'company_name'   => [
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Display company name', 'give-divi' ),
+				],
+				'status_notice'  => [
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Display status notice', 'give-divi' ),
+				],
+				'error'          => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Error notice text', 'give-divi' ),
+				],
+			],
+		];
+	}
+
+	/**
+	 * @param  WP_REST_Request  $request
+	 *
+	 * @return WP_REST_Response
+	 * @since 1.0.0
+	 */
+	public function handleRequest( WP_REST_Request $request ) {
+		$attributes = [
+			'donor'          => $request->get_param( 'donor' ),
+			'price'          => $request->get_param( 'price' ),
+			'date'           => $request->get_param( 'date' ),
+			'payment_method' => $request->get_param( 'payment_method' ),
+			'payment_id'     => $request->get_param( 'payment_id' ),
+			'payment_status' => $request->get_param( 'payment_status' ),
+			'company_name'   => $request->get_param( 'company_name' ),
+			'status_notice'  => $request->get_param( 'status_notice' ),
+			'error'          => $request->get_param( 'error' ),
+		];
+
+		return new WP_REST_Response(
+			[
+				'status'  => true,
+				'content' => $this->donation->getReceiptPreview( $attributes ),
+			]
+		);
+	}
+
+}

--- a/src/Divi/Routes/RenderDonationReceipt.php
+++ b/src/Divi/Routes/RenderDonationReceipt.php
@@ -2,7 +2,6 @@
 
 namespace GiveDivi\Divi\Routes;
 
-use GiveDivi\Divi\Repositories\Donation;
 use WP_REST_Request;
 use WP_REST_Response;
 
@@ -14,20 +13,6 @@ class RenderDonationReceipt extends Endpoint {
 
 	/** @var string */
 	protected $endpoint = 'give-divi/render-donation-receipt';
-
-	/**
-	 * @var Donation
-	 */
-	private $donation;
-
-	/**
-	 * RenderDonationReceipt constructor.
-	 *
-	 * @param  Donation  $donation
-	 */
-	public function __construct( Donation $donation ) {
-		$this->donation = $donation;
-	}
 
 	/**
 	 * @inheritDoc
@@ -166,7 +151,7 @@ class RenderDonationReceipt extends Endpoint {
 		return new WP_REST_Response(
 			[
 				'status'  => true,
-				'content' => $this->donation->getReceiptPreview( $attributes ),
+				'content' => give_display_donation_receipt( $attributes ),
 			]
 		);
 	}

--- a/src/Divi/resources/js/give-divi.js
+++ b/src/Divi/resources/js/give-divi.js
@@ -4,7 +4,8 @@ import $ from 'jquery';
 import DonationForm from '../../Modules/DonationForm';
 import DonorWall from '../../Modules/DonorWall';
 import FormGoal from '../../Modules/FormGoal';
+import DonationReceipt from '../../Modules/DonationReceipt';
 
 $( window ).on( 'et_builder_api_ready', ( event, API ) => {
-	API.registerModules( [ DonationForm, DonorWall, FormGoal ] );
+	API.registerModules( [ DonationForm, DonorWall, FormGoal, DonationReceipt ] );
 } );


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #15 

## Description

This PR adds support for the Donation Receipt shortcode to be used as a Divi module.

## Affects
Adds new Give Donation Receipt Divi module.


## Visuals

![image](https://user-images.githubusercontent.com/4222590/105037631-8df4fa00-5a5e-11eb-9d7d-9a331dea9838.png)


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

1. Add a new page using Divi editor
2. Insert the Give Donation Receipt module
3. Test module on the front-end
