### PR TITLE
 Add Profile Editor Module 

### DIFF
--- a/src/Divi/Helpers/Modules.php
+++ b/src/Divi/Helpers/Modules.php
@@ -8,6 +8,7 @@ use GiveDivi\Divi\Modules\DonorWall\Module as DonorWallModule;
 use GiveDivi\Divi\Modules\FormGoal\Module as FormGoalModule;
 use GiveDivi\Divi\Modules\RegistrationForm\Module as RegistrationFormModule;
 use GiveDivi\Divi\Modules\LoginForm\Module as LoginFormModule;
+use GiveDivi\Divi\Modules\ProfileEditor\Module as ProfileEditorModule;
 
 // Module routes Routes
 use GiveDivi\Divi\Routes\RenderDonationForm;
@@ -15,6 +16,7 @@ use GiveDivi\Divi\Routes\RenderDonorWall;
 use GiveDivi\Divi\Routes\RenderFormGoal;
 use GiveDivi\Divi\Routes\RenderRegistrationForm;
 use GiveDivi\Divi\Routes\RenderLoginForm;
+use GiveDivi\Divi\Routes\RenderProfileEditor;
 
 /**
  * Class Modules
@@ -43,10 +45,14 @@ class Modules {
 			[
 				'module' => RegistrationFormModule::class,
 				'route'  => RenderRegistrationForm::class,
-      ],
-      [
+			],
+			[
 				'module' => LoginFormModule::class,
 				'route'  => RenderLoginForm::class,
+			],
+			[
+				'module' => ProfileEditorModule::class,
+				'route'  => RenderProfileEditor::class,
 			],
 		];
 	}

--- a/src/Divi/Modules/FormGoal/index.js
+++ b/src/Divi/Modules/FormGoal/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import API, { CancelToken } from '../../resources/js/api';
 import parse from 'html-react-parser';
 
-export default class DonorWall extends React.Component {
+export default class FormGoal extends React.Component {
 	static slug = 'give_form_goal';
 
 	constructor( props ) {

--- a/src/Divi/Modules/ProfileEditor/Module.php
+++ b/src/Divi/Modules/ProfileEditor/Module.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace GiveDivi\Divi\Modules\ProfileEditor;
+
+
+class Module extends \ET_Builder_Module {
+	/**
+	 * @var string
+	 */
+	public $slug;
+
+	/**
+	 * @var string
+	 */
+	public $vb_support;
+
+	/**
+	 * @var string[]
+	 */
+	protected $module_credits;
+
+	/**
+	 * Module constructor.
+	 */
+	public function __construct() {
+		$this->slug           = 'give_profile_editor';
+		$this->vb_support     = 'on';
+		$this->module_credits = [
+			'module_uri' => '',
+			'author'     => 'GiveWp',
+			'author_uri' => 'https://givewp.com',
+		];
+
+		parent::__construct();
+	}
+
+	public function init() {
+		$this->name = esc_html__( 'Give Profile Editor', 'give-divi' );
+	}
+
+	/**
+	 * Get module fields
+	 *
+	 * @return array[]
+	 */
+	public function get_fields() {
+		return [];
+	}
+
+	/**
+	 * Render profile editor
+	 *
+	 * @param  array  $attrs
+	 * @param  null  $content
+	 * @param  string  $render_slug
+	 *
+	 * @return string
+	 * @since 1.0.0
+	 */
+	public function render( $attrs, $content = null, $render_slug ) {
+		return give_profile_editor_shortcode( $attrs );
+	}
+}

--- a/src/Divi/Modules/ProfileEditor/index.js
+++ b/src/Divi/Modules/ProfileEditor/index.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import API, { CancelToken } from '../../resources/js/api';
+import parse from 'html-react-parser';
+
+export default class ProfileEditor extends React.Component {
+	static slug = 'give_profile_editor';
+
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			content: null,
+		};
+	}
+
+	componentDidMount() {
+		API.post( '/render-profile-editor', { cancelToken: CancelToken.token } )
+			.then( ( response ) => {
+				this.setState( {
+					content: response.data.content,
+				} );
+			} )
+			.catch( () => {
+				CancelToken.cancel();
+				this.setState( {
+					content: '',
+				} );
+			} );
+	}
+
+	render() {
+		return (
+			<>{ this.state.content && parse( this.state.content ) }</>
+		);
+	}
+}

--- a/src/Divi/Routes/RenderProfileEditor.php
+++ b/src/Divi/Routes/RenderProfileEditor.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace GiveDivi\Divi\Routes;
+
+use WP_REST_Response;
+
+/**
+ * Class RenderProfileEditor
+ * @package GiveDivi\Divi\Routes
+ */
+class RenderProfileEditor extends Endpoint {
+
+	/** @var string */
+	protected $endpoint = 'give-divi/render-profile-editor';
+
+
+	/**
+	 * @inheritDoc
+	 */
+	public function registerRoute() {
+		register_rest_route(
+			'give-api/v2',
+			$this->endpoint,
+			[
+				[
+					'methods'             => 'POST',
+					'callback'            => [ $this, 'handleRequest' ],
+					'permission_callback' => [ $this, 'permissionsCheck' ],
+					'args'                => [],
+				],
+				'schema' => [ $this, 'getSchema' ],
+			]
+		);
+	}
+
+	/**
+	 * @return array
+	 * @since 1.0.0
+	 */
+	public function getSchema() {
+		return [
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'give-divi',
+			'type'       => 'object',
+			'properties' => [],
+		];
+	}
+
+	/**
+	 * @return WP_REST_Response
+	 * @since 1.0.0
+	 */
+	public function handleRequest() {
+		return new WP_REST_Response(
+			[
+				'status'  => true,
+				'content' => give_profile_editor_shortcode( [] ),
+			]
+		);
+	}
+
+}

--- a/src/Divi/resources/js/give-divi.js
+++ b/src/Divi/resources/js/give-divi.js
@@ -6,7 +6,8 @@ import DonorWall from '../../Modules/DonorWall';
 import FormGoal from '../../Modules/FormGoal';
 import RegistrationForm from '../../Modules/RegistrationForm';
 import LoginForm from '../../Modules/LoginForm';
+import ProfileEditor from '../../Modules/ProfileEditor';
 
 $( window ).on( 'et_builder_api_ready', ( event, API ) => {
-	API.registerModules( [ DonationForm, DonorWall, FormGoal, RegistrationForm, LoginForm ] );
+	API.registerModules( [ DonationForm, DonorWall, FormGoal, RegistrationForm, LoginForm, ProfileEditor ] );
 } );


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #17

## Description

This PR adds support for the Profile Editor shortcode to be used as a Divi module.

## Affects

Adds new Give Profile Editor Divi module.

## Visuals

![image](https://user-images.githubusercontent.com/4222590/105164822-e6d39980-5b15-11eb-9720-55a457aca04f.png)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

1. Add a new page using Divi editor
2. Insert the Give Profile Editor module
3. Test module on the front-end
