### PR TITLE
Add Totals Module 

### DIFF
--- a/src/Divi/Helpers/Modules.php
+++ b/src/Divi/Helpers/Modules.php
@@ -8,6 +8,7 @@ use GiveDivi\Divi\Modules\DonorWall\Module as DonorWallModule;
 use GiveDivi\Divi\Modules\FormGoal\Module as FormGoalModule;
 use GiveDivi\Divi\Modules\RegistrationForm\Module as RegistrationFormModule;
 use GiveDivi\Divi\Modules\LoginForm\Module as LoginFormModule;
+use GiveDivi\Divi\Modules\Totals\Module as TotalsModule;
 
 // Module routes Routes
 use GiveDivi\Divi\Routes\RenderDonationForm;
@@ -15,6 +16,7 @@ use GiveDivi\Divi\Routes\RenderDonorWall;
 use GiveDivi\Divi\Routes\RenderFormGoal;
 use GiveDivi\Divi\Routes\RenderRegistrationForm;
 use GiveDivi\Divi\Routes\RenderLoginForm;
+use GiveDivi\Divi\Routes\RenderTotals;
 
 /**
  * Class Modules
@@ -43,10 +45,14 @@ class Modules {
 			[
 				'module' => RegistrationFormModule::class,
 				'route'  => RenderRegistrationForm::class,
-      ],
-      [
+			],
+			[
 				'module' => LoginFormModule::class,
 				'route'  => RenderLoginForm::class,
+			],
+			[
+				'module' => TotalsModule::class,
+				'route'  => RenderTotals::class,
 			],
 		];
 	}

--- a/src/Divi/Modules/Totals/Module.php
+++ b/src/Divi/Modules/Totals/Module.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace GiveDivi\Divi\Modules\Totals;
+
+class Module extends \ET_Builder_Module {
+
+	public $slug       = 'give_totals';
+	public $vb_support = 'on';
+
+	protected $module_credits = [
+		'module_uri' => '',
+		'author'     => 'GiveWp',
+		'author_uri' => 'https://givewp.com',
+	];
+
+	public function init() {
+		$this->name = esc_html__( 'Give Totals', 'give-divi' );
+	}
+
+	/**
+	 * Get module fields
+	 *
+	 * @return array[]
+	 */
+	public function get_fields() {
+		return [
+			'total_goal'   => [
+				'label'           => esc_html__( 'Total Goal', 'give-divi' ),
+				'type'            => 'text',
+				'option_category' => 'basic_option',
+				'default'         => '',
+			],
+			'ids'          => [
+				'label'           => esc_html__( 'Donation Form IDs', 'give-divi' ),
+				'type'            => 'text',
+				'option_category' => 'basic_option',
+				'default'         => '',
+			],
+			'cats'         => [
+				'label'           => esc_html__( 'Categories', 'give-divi' ),
+				'type'            => 'text',
+				'option_category' => 'basic_option',
+				'default'         => '',
+			],
+			'tags'         => [
+				'label'           => esc_html__( 'Tags', 'give-divi' ),
+				'type'            => 'text',
+				'option_category' => 'basic_option',
+				'default'         => '',
+			],
+			'message'      => [
+				'label'           => esc_html__( 'Message', 'give-divi' ),
+				'type'            => 'text',
+				'option_category' => 'basic_option',
+				'default'         => '',
+			],
+			'link'         => [
+				'label'           => esc_html__( 'Link', 'give-divi' ),
+				'type'            => 'text',
+				'option_category' => 'basic_option',
+				'default'         => '',
+			],
+			'link_text'    => [
+				'label'           => esc_html__( 'Link Text', 'give-divi' ),
+				'type'            => 'text',
+				'option_category' => 'basic_option',
+				'default'         => esc_html__( 'Donate Now', 'give-divi' ),
+			],
+			'progress_bar' => [
+				'label'           => esc_html__( 'Show progress bar', 'give-divi' ),
+				'type'            => 'yes_no_button',
+				'option_category' => 'basic_option',
+				'options'         => [ 'off', 'on' ],
+				'default'         => 'on',
+			],
+		];
+	}
+
+	/**
+	 * Render donation form
+	 *
+	 * @param  array  $attrs
+	 * @param  null  $content
+	 * @param  string  $render_slug
+	 *
+	 * @return string|void
+	 * @since 1.0.0
+	 */
+	public function render( $attrs, $content = null, $render_slug ) {
+		$message    = apply_filters(
+			'give_totals_message',
+			__( 'Hey! We\'ve raised {total} of the {total_goal} we are trying to raise for this campaign!', 'give-divi' )
+		);
+		$attributes = [
+			'total_goal'   => isset( $attrs['total_goal'] ) ? (int) $attrs['total_goal'] : 0,
+			'ids'          => isset( $attrs['ids'] ) ? esc_attr( $attrs['ids'] ) : 0,
+			'cats'         => isset( $attrs['cats'] ) ? esc_attr( $attrs['cats'] ) : 0,
+			'tags'         => isset( $attrs['tags'] ) ? esc_attr( $attrs['tags'] ) : 0,
+			'message'      => isset( $attrs['message'] ) ? esc_html( $attrs['message'] ) : $message,
+			'link'         => isset( $attrs['link'] ) ? esc_url( $attrs['link'] ) : '',
+			'link_text'    => isset( $attrs['link_text'] ) ? esc_html( $attrs['link_text'] ) : esc_html__( 'Donate Now', 'give-divi' ),
+			'progress_bar' => isset( $attrs['anonymous'] ) ? filter_var( $attrs['anonymous'], FILTER_VALIDATE_BOOLEAN ) : true,
+		];
+
+		return give_totals_shortcode( $attributes );
+	}
+}

--- a/src/Divi/Modules/Totals/index.js
+++ b/src/Divi/Modules/Totals/index.js
@@ -1,0 +1,92 @@
+import React from 'react';
+import API, { CancelToken } from '../../resources/js/api';
+import parse from 'html-react-parser';
+
+export default class Totals extends React.Component {
+	static slug = 'give_totals';
+
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			fetching: false,
+			content: null,
+		};
+	}
+
+	getSnapshotBeforeUpdate( prevProps ) {
+		if (
+			prevProps.total_goal !== this.props.total_goal ||
+			prevProps.ids !== this.props.ids ||
+			prevProps.cats !== this.props.cats ||
+			prevProps.tags !== this.props.tags ||
+			prevProps.message !== this.props.message ||
+			prevProps.link !== this.props.link ||
+			prevProps.link_text !== this.props.link_text ||
+			prevProps.progress_bar !== this.props.progress_bar
+		) {
+			return {
+				total_goal: this.props.total_goal,
+				ids: this.props.ids,
+				cats: this.props.cats,
+				tags: this.props.tags,
+				message: this.props.message,
+				link: this.props.link,
+				link_text: this.props.link_text,
+				progress_bar: this.props.progress_bar === 'on',
+			};
+		}
+
+		return null;
+	}
+
+	componentDidMount() {
+		const params = {
+			total_goal: this.props.total_goal,
+			ids: this.props.ids,
+			cats: this.props.cats,
+			tags: this.props.tags,
+			message: this.props.message,
+			link: this.props.link,
+			link_text: this.props.link_text,
+			progress_bar: this.props.progress_bar === 'on',
+		};
+
+		this.fetchDonorWall( params );
+	}
+
+	componentDidUpdate( prevProps, prevState, snapshot ) {
+		if ( snapshot && ! this.state.fetching ) {
+			this.fetchDonorWall( snapshot );
+		}
+	}
+
+	fetchDonorWall( params ) {
+		this.setState(
+			{
+				fetching: true,
+			}
+		);
+
+		API.post( '/render-totals', params, { cancelToken: CancelToken.token } )
+			.then( ( response ) => {
+				this.setState( {
+					fetching: false,
+					content: response.data.content,
+				} );
+			} )
+			.catch( () => {
+				CancelToken.cancel();
+				this.setState( {
+					fetching: false,
+					content: '',
+				} );
+			} );
+	}
+
+	render() {
+		return (
+			<>{ this.state.content && parse( this.state.content ) }</>
+		);
+	}
+}

--- a/src/Divi/Routes/Endpoint.php
+++ b/src/Divi/Routes/Endpoint.php
@@ -21,7 +21,7 @@ abstract class Endpoint implements RestRoute {
 	 * @return bool|WP_Error
 	 */
 	public function permissionsCheck() {
-		if ( ! current_user_can( 'edit_page' ) ) {
+		if ( ! current_user_can( 'edit_posts' ) ) {
 			return new WP_Error(
 				'rest_forbidden',
 				esc_html__( 'You dont have the right permissions to use Give Divi Add-on', 'give-divi' ),

--- a/src/Divi/Routes/RenderTotals.php
+++ b/src/Divi/Routes/RenderTotals.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace GiveDivi\Divi\Routes;
+
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Class RenderTotals
+ * @package GiveDivi\Divi\Routes
+ */
+class RenderTotals extends Endpoint {
+
+	/** @var string */
+	protected $endpoint = 'give-divi/render-totals';
+
+
+	/**
+	 * @inheritDoc
+	 */
+	public function registerRoute() {
+		register_rest_route(
+			'give-api/v2',
+			$this->endpoint,
+			[
+				[
+					'methods'             => 'POST',
+					'callback'            => [ $this, 'handleRequest' ],
+					'permission_callback' => [ $this, 'permissionsCheck' ],
+					'args'                => [
+						'total_goal'   => [
+							'type'     => 'string',
+							'required' => false,
+						],
+						'ids'          => [
+							'type'     => 'string',
+							'required' => false,
+						],
+						'cats'         => [
+							'type'     => 'string',
+							'required' => false,
+						],
+						'tags'         => [
+							'type'     => 'string',
+							'required' => false,
+						],
+						'message'      => [
+							'type'     => 'string',
+							'required' => false,
+						],
+						'link'         => [
+							'type'     => 'string',
+							'required' => false,
+						],
+						'link_text'    => [
+							'type'     => 'string',
+							'required' => false,
+							'default'  => esc_html__( 'Donate Now', 'give-divi' ),
+						],
+						'progress_bar' => [
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => true,
+						],
+					],
+				],
+				'schema' => [ $this, 'getSchema' ],
+			]
+		);
+	}
+
+	/**
+	 * @return array
+	 * @since 1.0.0
+	 */
+	public function getSchema() {
+		return [
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'give-divi',
+			'type'       => 'object',
+			'properties' => [
+				'total_goal'   => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Total Goal', 'give-divi' ),
+				],
+				'ids'          => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Donation Form IDs', 'give-divi' ),
+				],
+				'cats'         => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Categories', 'give-divi' ),
+				],
+				'tags'         => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Tags', 'give-divi' ),
+				],
+				'message'      => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Message', 'give-divi' ),
+				],
+				'link'         => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Link', 'give-divi' ),
+				],
+				'link_text'    => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Link Text', 'give-divi' ),
+				],
+				'progress_bar' => [
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Show progress bar', 'give-divi' ),
+				],
+			],
+		];
+	}
+
+	/**
+	 * @param  WP_REST_Request  $request
+	 *
+	 * @return WP_REST_Response
+	 * @since 1.0.0
+	 */
+	public function handleRequest( WP_REST_Request $request ) {
+		$attributes = [
+			'total_goal'   => $request->get_param( 'total_goal' ),
+			'ids'          => $request->get_param( 'ids' ),
+			'cats'         => $request->get_param( 'cats' ),
+			'tags'         => $request->get_param( 'tags' ),
+			'message'      => $request->get_param( 'message' ),
+			'link'         => $request->get_param( 'link' ),
+			'link_text'    => $request->get_param( 'link_text' ),
+			'progress_bar' => $request->get_param( 'progress_bar' ),
+		];
+
+		return new WP_REST_Response(
+			[
+				'status'  => true,
+				'content' => give_totals_shortcode( $attributes ),
+			]
+		);
+	}
+}

--- a/src/Divi/resources/js/give-divi.js
+++ b/src/Divi/resources/js/give-divi.js
@@ -6,7 +6,8 @@ import DonorWall from '../../Modules/DonorWall';
 import FormGoal from '../../Modules/FormGoal';
 import RegistrationForm from '../../Modules/RegistrationForm';
 import LoginForm from '../../Modules/LoginForm';
+import Totals from '../../Modules/Totals';
 
 $( window ).on( 'et_builder_api_ready', ( event, API ) => {
-	API.registerModules( [ DonationForm, DonorWall, FormGoal, RegistrationForm, LoginForm ] );
+	API.registerModules( [ DonationForm, DonorWall, FormGoal, RegistrationForm, LoginForm, Totals ] );
 } );


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #19 

## Description

This PR adds support for the Totals shortcode to be used as a Divi module.

## Affects

Adds new Give Totals Divi module.

## Visuals

![image](https://user-images.githubusercontent.com/4222590/105173742-bb56ac00-5b21-11eb-9a16-4c919bb1d6ca.png)


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

1. Add a new page using Divi editor
2. Insert the Give Totals module
3. Test module on the front-end

