### PR TITLE
Add Form Grid Module

### DIFF
--- a/src/Divi/Helpers/Modules.php
+++ b/src/Divi/Helpers/Modules.php
@@ -8,6 +8,7 @@ use GiveDivi\Divi\Modules\DonorWall\Module as DonorWallModule;
 use GiveDivi\Divi\Modules\FormGoal\Module as FormGoalModule;
 use GiveDivi\Divi\Modules\RegistrationForm\Module as RegistrationFormModule;
 use GiveDivi\Divi\Modules\LoginForm\Module as LoginFormModule;
+use GiveDivi\Divi\Modules\FormGrid\Module as FormGridModule;
 
 // Module routes Routes
 use GiveDivi\Divi\Routes\RenderDonationForm;
@@ -15,6 +16,7 @@ use GiveDivi\Divi\Routes\RenderDonorWall;
 use GiveDivi\Divi\Routes\RenderFormGoal;
 use GiveDivi\Divi\Routes\RenderRegistrationForm;
 use GiveDivi\Divi\Routes\RenderLoginForm;
+use GiveDivi\Divi\Routes\RenderFormGrid;
 
 /**
  * Class Modules
@@ -43,10 +45,14 @@ class Modules {
 			[
 				'module' => RegistrationFormModule::class,
 				'route'  => RenderRegistrationForm::class,
-      ],
-      [
+			],
+			[
 				'module' => LoginFormModule::class,
 				'route'  => RenderLoginForm::class,
+			],
+			[
+				'module' => FormGridModule::class,
+				'route'  => RenderFormGrid::class,
 			],
 		];
 	}
@@ -58,7 +64,7 @@ class Modules {
 	 */
 	public static function getModules() {
 		return array_map(
-			function( $module ) {
+			function ( $module ) {
 				return $module['module'];
 			},
 			static::config()
@@ -73,7 +79,7 @@ class Modules {
 	 */
 	public static function getRoutes() {
 		return array_map(
-			function( $module ) {
+			function ( $module ) {
 				return $module['route'];
 			},
 			static::config()

--- a/src/Divi/Modules/FormGrid/Module.php
+++ b/src/Divi/Modules/FormGrid/Module.php
@@ -1,0 +1,229 @@
+<?php
+
+namespace GiveDivi\Divi\Modules\FormGrid;
+
+class Module extends \ET_Builder_Module {
+
+	public $slug       = 'give_form_grid';
+	public $vb_support = 'on';
+
+	protected $module_credits = [
+		'module_uri' => '',
+		'author'     => 'GiveWp',
+		'author_uri' => 'https://givewp.com',
+	];
+
+	public function init() {
+		$this->name = esc_html__( 'Give Form Grid', 'give-divi' );
+	}
+
+	/**
+	 * Get module fields
+	 *
+	 * @return array[]
+	 */
+	public function get_fields() {
+		return [
+			'forms_per_page'      => [
+				'label'           => esc_html__( 'Forms per page', 'give-divi' ),
+				'type'            => 'range',
+				'option_category' => 'basic_option',
+				'range_settings'  => [
+					'min'  => '1',
+					'max'  => '100',
+					'step' => '1',
+				],
+				'default'         => '12',
+				'description'     => esc_html__( 'Shows how many forms will display per page. Pagination controls will be visible if more forms exist', 'give-divi' ),
+			],
+			'ids'                 => [
+				'label'           => esc_html__( 'Form IDs', 'give-divi' ),
+				'type'            => 'text',
+				'option_category' => 'basic_option',
+				'default'         => '',
+				'description'     => esc_html__( 'Show forms based on ID. By default, all forms appear on the grid. A comma-separated list of form IDs will cause the grid to include only those forms, default “All Forms”', 'give-divi' ),
+			],
+			'exclude'             => [
+				'label'           => esc_html__( 'Exclude Forms by ID', 'give-divi' ),
+				'type'            => 'text',
+				'option_category' => 'basic_option',
+				'default'         => '',
+				'description'     => esc_html__( 'Exclude one or more forms from the grid. A comma-separated list of form IDs will cause the grid to exclude only those forms.', 'give-divi' ),
+			],
+			'orderby'             => [
+				'label'           => esc_html__( 'Order by', 'give-divi' ),
+				'type'            => 'select',
+				'option_category' => 'basic_option',
+				'options'         => [
+					'date'             => esc_html__( 'Date', 'give-divi' ),
+					'title'            => esc_html__( 'Title', 'give-divi' ),
+					'amount_donated'   => esc_html__( 'Amount Donated', 'give-divi' ),
+					'number_donations' => esc_html__( 'Number Donations', 'give-divi' ),
+					'menu_order'       => esc_html__( 'Menu order', 'give-divi' ),
+					'closest_to_goal'  => esc_html__( 'Closest to goal', 'give-divi' ),
+				],
+				'default'         => 'date',
+				'description'     => esc_html__( 'Choose the parameters by which the forms appear.', 'give-divi' ),
+			],
+			'order'               => [
+				'label'           => esc_html__( 'Order', 'give-divi' ),
+				'type'            => 'select',
+				'option_category' => 'basic_option',
+				'options'         => [
+					'DESC' => esc_html__( 'Descending', 'give-divi' ),
+					'ASC'  => esc_html__( 'Ascending', 'give-divi' ),
+				],
+				'default'         => 'DESC',
+				'description'     => esc_html__( 'Choose the order in which the donors appear, according to the Order by choice.', 'give-divi' ),
+			],
+			'columns'             => [
+				'label'           => esc_html__( 'Columns', 'give-divi' ),
+				'type'            => 'select',
+				'option_category' => 'basic_option',
+				'options'         => [
+					'best-fit' => esc_html__( 'Best Fit', 'give-divi' ),
+					'1',
+					'2',
+					'3',
+					'4',
+				],
+				'default'         => 'best-fit',
+				'description'     => esc_html__( 'Set the number of columns you would like to display in your grid.', 'give-divi' ),
+			],
+			'cats'                => [
+				'label'           => esc_html__( 'Categories', 'give-divi' ),
+				'type'            => 'text',
+				'option_category' => 'basic_option',
+				'default'         => '',
+				'description'     => esc_html__( 'If you have categories enabled in GiveWP, you can list the category IDs that you want displayed in this grid. A comma-separated list of form category IDs will cause the grid to include only forms from those categories.', 'give-divi' ),
+			],
+			'tags'                => [
+				'label'           => esc_html__( 'Tags', 'give-divi' ),
+				'type'            => 'text',
+				'option_category' => 'basic_option',
+				'default'         => '',
+				'description'     => esc_html__( 'If you have tags enabled in GiveWP, you can list the category IDs that you want displayed in this grid. A comma-separated list of form tag IDs will cause the grid to include only forms with those tags.', 'give-divi' ),
+			],
+			'show_title'          => [
+				'label'           => esc_html__( 'Show Title', 'give-divi' ),
+				'type'            => 'yes_no_button',
+				'option_category' => 'basic_option',
+				'options'         => [ 'off', 'on' ],
+				'default'         => 'on',
+				'description'     => esc_html__( 'This enables/disables display of the title in the form.', 'give-divi' ),
+			],
+			'show_goal'           => [
+				'label'           => esc_html__( 'Show Goal', 'give-divi' ),
+				'type'            => 'yes_no_button',
+				'option_category' => 'basic_option',
+				'options'         => [ 'off', 'on' ],
+				'default'         => 'on',
+				'description'     => esc_html__( 'This shows the progress bar of the forms, if a goal has been enabled in the form.', 'give-divi' ),
+			],
+			'show_excerpt'        => [
+				'label'           => esc_html__( 'Show Excerpt', 'give-divi' ),
+				'type'            => 'yes_no_button',
+				'option_category' => 'basic_option',
+				'options'         => [ 'off', 'on' ],
+				'default'         => 'on',
+				'description'     => esc_html__( 'This enables/disables display of the form content in the form.', 'give-divi' ),
+			],
+			'show_featured_image' => [
+				'label'           => esc_html__( 'Show Featured Image', 'give-divi' ),
+				'type'            => 'yes_no_button',
+				'option_category' => 'basic_option',
+				'options'         => [ 'off', 'on' ],
+				'default'         => 'on',
+				'description'     => esc_html__( 'Choose if the featured image of the form is shown.', 'give-divi' ),
+			],
+			'image_size'          => [
+				'label'           => esc_html__( 'Featured Image Size', 'give-divi' ),
+				'type'            => 'select',
+				'option_category' => 'basic_option',
+				'options'         => [
+					'small'  => esc_html__( 'Small', 'give-divi' ),
+					'medium' => esc_html__( 'Medium', 'give-divi' ),
+					'large'  => esc_html__( 'Large', 'give-divi' ),
+				],
+				'default'         => 'medium',
+				'description'     => esc_html__( 'This sets the featured image size used within the card display based on your Media Settings. It will not change the actual card display size itself.', 'give-divi' ),
+			],
+			'image_height'        => [
+				'label'           => esc_html__( 'Featured Image Height', 'give-divi' ),
+				'type'            => 'text',
+				'option_category' => 'basic_option',
+				'default'         => 'auto',
+				'description'     => esc_html__( 'Adjust the height of the featured image.', 'give-divi' ),
+			],
+			'excerpt_length'      => [
+				'label'           => esc_html__( 'Excerpt Size', 'give-divi' ),
+				'type'            => 'range',
+				'option_category' => 'basic_option',
+				'range_settings'  => [
+					'min'  => '1',
+					'max'  => '55',
+					'step' => '1',
+				],
+				'validate_unit'   => true,
+				'default'         => '16',
+				'description'     => esc_html__( 'You can truncate the exact word-length of the excerpt displayed with this argument.', 'give-divi' ),
+			],
+			'style'               => [
+				'label'           => esc_html__( 'Display Type', 'give-divi' ),
+				'type'            => 'select',
+				'option_category' => 'basic_option',
+				'options'         => [
+					'modal_reveal' => esc_html__( 'Modal reveal', 'give-divi' ),
+					'redirect'     => esc_html__( 'Redirect', 'give-divi' ),
+				],
+				'default'         => 'modal_reveal',
+				'description'     => esc_html__( 'Show form as modal window or redirect to the form page.', 'give-divi' ),
+			],
+			'status'              => [
+				'label'           => esc_html__( 'Status', 'give-divi' ),
+				'type'            => 'select',
+				'option_category' => 'basic_option',
+				'options'         => [
+					''       => esc_html__( 'Select status', 'give-divi' ),
+					'open'   => esc_html__( 'Open', 'give-divi' ),
+					'closed' => esc_html__( 'Closed', 'give-divi' ),
+				],
+				'default'         => '',
+			],
+		];
+	}
+
+	/**
+	 * Render donation form
+	 *
+	 * @param  array  $attrs
+	 * @param  null  $content
+	 * @param  string  $render_slug
+	 *
+	 * @return string|void
+	 * @since 1.0.0
+	 */
+	public function render( $attrs, $content = null, $render_slug ) {
+		$attributes = [
+			'forms_per_page'      => isset( $attrs['forms_per_page'] ) ? (int) $attrs['forms_per_page'] : 12,
+			'ids'                 => isset( $attrs['ids'] ) ? $attrs['ids'] : '',
+			'exclude'             => isset( $attrs['exclude'] ) ? $attrs['exclude'] : '',
+			'orderby'             => isset( $attrs['orderby'] ) ? $attrs['orderby'] : 'date',
+			'order'               => isset( $attrs['order'] ) ? $attrs['order'] : 'DESC',
+			'columns'             => isset( $attrs['columns'] ) ? $attrs['columns'] : 'best-fit',
+			'cats'                => isset( $attrs['cats'] ) ? $attrs['cats'] : '',
+			'tags'                => isset( $attrs['tags'] ) ? $attrs['tags'] : '',
+			'show_title'          => isset( $attrs['show_title'] ) ? filter_var( $attrs['show_title'], FILTER_VALIDATE_BOOLEAN ) : true,
+			'show_goal'           => isset( $attrs['show_goal'] ) ? filter_var( $attrs['show_goal'], FILTER_VALIDATE_BOOLEAN ) : true,
+			'show_excerpt'        => isset( $attrs['show_excerpt'] ) ? filter_var( $attrs['show_excerpt'], FILTER_VALIDATE_BOOLEAN ) : true,
+			'show_featured_image' => isset( $attrs['show_featured_image'] ) ? filter_var( $attrs['show_featured_image'], FILTER_VALIDATE_BOOLEAN ) : false,
+			'image_size'          => isset( $attrs['image_size'] ) ? $attrs['image_size'] : 'medium',
+			'image_height'        => isset( $attrs['image_height'] ) ? $attrs['image_height'] : 'auto',
+			'excerpt_length'      => isset( $attrs['excerpt_length'] ) ? (int) $attrs['excerpt_length'] : 160,
+			'style'               => isset( $attrs['style'] ) ? $attrs['style'] : 'modal_reveal',
+			'status'              => isset( $attrs['status'] ) ? $attrs['status'] : '',
+		];
+
+		return give_form_grid_shortcode( $attributes );
+	}
+}

--- a/src/Divi/Modules/FormGrid/index.js
+++ b/src/Divi/Modules/FormGrid/index.js
@@ -1,0 +1,119 @@
+import React from 'react';
+import API, { CancelToken } from '../../resources/js/api';
+import parse from 'html-react-parser';
+
+export default class FormGrid extends React.Component {
+	static slug = 'give_form_grid';
+
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			fetching: false,
+			content: null,
+		};
+	}
+
+	getSnapshotBeforeUpdate( prevProps ) {
+		if (
+			prevProps.forms_per_page !== this.props.forms_per_page ||
+			prevProps.ids !== this.props.ids ||
+			prevProps.exclude !== this.props.exclude ||
+			prevProps.orderby !== this.props.orderby ||
+			prevProps.order !== this.props.order ||
+			prevProps.columns !== this.props.columns ||
+			prevProps.cats !== this.props.cats ||
+			prevProps.tags !== this.props.tags ||
+			prevProps.show_title !== this.props.show_title ||
+			prevProps.show_goal !== this.props.show_goal ||
+			prevProps.show_excerpt !== this.props.show_excerpt ||
+			prevProps.show_featured_image !== this.props.show_featured_image ||
+			prevProps.image_size !== this.props.image_size ||
+			prevProps.image_height !== this.props.image_height ||
+			prevProps.excerpt_length !== this.props.excerpt_length ||
+			prevProps.style !== this.props.style ||
+			prevProps.status !== this.props.status
+		) {
+			return {
+				forms_per_page: this.props.forms_per_page,
+				ids: this.props.ids,
+				exclude: this.props.exclude,
+				orderby: this.props.orderby,
+				order: this.props.order,
+				columns: this.props.columns,
+				cats: this.props.cats,
+				tags: this.props.tags,
+				show_title: this.props.show_title === 'on',
+				show_goal: this.props.show_goal === 'on',
+				show_excerpt: this.props.show_excerpt === 'on',
+				show_featured_image: this.props.show_featured_image === 'on',
+				image_size: this.props.image_size,
+				image_height: this.props.image_height,
+				excerpt_length: this.props.excerpt_length,
+				style: this.props.style,
+				status: this.props.status,
+			};
+		}
+
+		return null;
+	}
+
+	componentDidMount() {
+		this.fetchFormGrid(
+			{
+				forms_per_page: this.props.forms_per_page,
+				ids: this.props.ids,
+				exclude: this.props.exclude,
+				orderby: this.props.orderby,
+				order: this.props.order,
+				columns: this.props.columns,
+				cats: this.props.cats,
+				tags: this.props.tags,
+				show_title: this.props.show_title === 'on',
+				show_goal: this.props.show_goal === 'on',
+				show_excerpt: this.props.show_excerpt === 'on',
+				show_featured_image: this.props.show_featured_image === 'on',
+				image_size: this.props.image_size,
+				image_height: this.props.image_height,
+				excerpt_length: this.props.excerpt_length,
+				style: this.props.style,
+				status: this.props.status,
+			}
+		);
+	}
+
+	componentDidUpdate( prevProps, prevState, snapshot ) {
+		if ( snapshot && ! this.state.fetching ) {
+			this.fetchFormGrid( snapshot );
+		}
+	}
+
+	fetchFormGrid( params ) {
+		this.setState(
+			{
+				fetching: true,
+			}
+		);
+
+		API.post( '/render-form-grid', params, { cancelToken: CancelToken.token } )
+			.then( ( response ) => {
+				this.setState( {
+					fetching: false,
+					content: response.data.content,
+				} );
+			} )
+			.catch( () => {
+				CancelToken.cancel();
+				this.setState( {
+					fetching: false,
+					content: '',
+				} );
+			} );
+	}
+
+	render() {
+		return (
+			<>{ this.state.content && parse( this.state.content ) }</>
+		);
+	}
+}

--- a/src/Divi/Routes/RenderFormGrid.php
+++ b/src/Divi/Routes/RenderFormGrid.php
@@ -1,0 +1,241 @@
+<?php
+
+namespace GiveDivi\Divi\Routes;
+
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Class RenderFormGrid
+ * @package GiveDivi\Divi\Routes
+ */
+class RenderFormGrid extends Endpoint {
+
+	/** @var string */
+	protected $endpoint = 'give-divi/render-form-grid';
+
+
+	/**
+	 * @inheritDoc
+	 */
+	public function registerRoute() {
+		register_rest_route(
+			'give-api/v2',
+			$this->endpoint,
+			[
+				[
+					'methods'             => 'POST',
+					'callback'            => [ $this, 'handleRequest' ],
+					'permission_callback' => [ $this, 'permissionsCheck' ],
+					'args'                => [
+						'forms_per_page'      => [
+							'type'     => 'integer',
+							'required' => false,
+							'default'  => 12,
+						],
+						'ids'                 => [
+							'type'     => 'string',
+							'required' => false,
+							'default'  => '',
+						],
+						'exclude'             => [
+							'type'     => 'string',
+							'required' => false,
+							'default'  => '',
+						],
+						'orderby'             => [
+							'type'     => 'string',
+							'required' => false,
+							'default'  => 'desc',
+						],
+						'order'               => [
+							'type'     => 'string',
+							'required' => false,
+							'default'  => 'amount',
+						],
+						'columns'             => [
+							'type'     => 'string',
+							'required' => false,
+							'default'  => 'best-fit',
+						],
+						'cats'                => [
+							'type'     => 'string',
+							'required' => false,
+							'default'  => '',
+						],
+						'tags'                => [
+							'type'     => 'string',
+							'required' => false,
+							'default'  => '',
+						],
+						'show_title'          => [
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => 'true',
+						],
+						'show_goal'           => [
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => true,
+						],
+						'show_excerpt'        => [
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => true,
+						],
+						'show_featured_image' => [
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => true,
+						],
+						'image_size'          => [
+							'type'     => 'string',
+							'required' => false,
+							'default'  => 'medium',
+						],
+						'image_height'        => [
+							'type'     => 'string',
+							'required' => false,
+							'default'  => 'auto',
+						],
+						'excerpt_length'      => [
+							'type'     => 'integer',
+							'required' => false,
+							'default'  => 16,
+						],
+						'style'               => [
+							'type'     => 'string',
+							'required' => false,
+							'default'  => 'modal_reveal',
+						],
+						'status'              => [
+							'type'     => 'string',
+							'required' => false,
+							'default'  => ' ',
+						],
+					],
+				],
+				'schema' => [ $this, 'getSchema' ],
+			]
+		);
+	}
+
+	/**
+	 * @return array
+	 * @since 1.0.0
+	 */
+	public function getSchema() {
+		return [
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'give-divi',
+			'type'       => 'object',
+			'properties' => [
+				'forms_per_page'      => [
+					'type'        => 'integer',
+					'description' => esc_html__( 'Forms per page', 'give-divi' ),
+				],
+				'ids'                 => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Forms IDs', 'give-divi' ),
+				],
+				'exclude'             => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Exclude Forms IDs', 'give-divi' ),
+				],
+				'orderby'             => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Order By', 'give-divi' ),
+				],
+				'order'               => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Order', 'give-divi' ),
+				],
+				'columns'             => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Columns', 'give-divi' ),
+				],
+				'cats'                => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Categories', 'give-divi' ),
+				],
+				'tags'                => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Tags', 'give-divi' ),
+				],
+				'show_title'          => [
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Show Title', 'give-divi' ),
+				],
+				'show_goal'           => [
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Show Goal', 'give-divi' ),
+				],
+				'show_excerpt'        => [
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Show Excerpt', 'give-divi' ),
+				],
+				'show_featured_image' => [
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Show Featured Image', 'give-divi' ),
+				],
+				'image_size'          => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Image Size', 'give-divi' ),
+				],
+				'image_height'        => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Image Height', 'give-divi' ),
+				],
+				'excerpt_length'      => [
+					'type'        => 'integer',
+					'description' => esc_html__( 'Excerpt Length', 'give-divi' ),
+				],
+				'style'               => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Display Style', 'give-divi' ),
+				],
+				'status'              => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Status', 'give-divi' ),
+				],
+			],
+		];
+	}
+
+	/**
+	 * @param  WP_REST_Request  $request
+	 *
+	 * @return WP_REST_Response
+	 * @since 1.0.0
+	 */
+	public function handleRequest( WP_REST_Request $request ) {
+		$attributes = [
+			'forms_per_page'      => $request->get_param( 'forms_per_page' ),
+			'ids'                 => $request->get_param( 'ids' ),
+			'exclude'             => $request->get_param( 'exclude' ),
+			'orderby'             => $request->get_param( 'orderby' ),
+			'order'               => $request->get_param( 'order' ),
+			'columns'             => $request->get_param( 'columns' ),
+			'cats'                => $request->get_param( 'cats' ),
+			'tags'                => $request->get_param( 'tags' ),
+			'show_title'          => $request->get_param( 'show_title' ),
+			'show_goal'           => $request->get_param( 'show_goal' ),
+			'show_excerpt'        => $request->get_param( 'show_excerpt' ),
+			'show_featured_image' => $request->get_param( 'show_featured_image' ),
+			'image_size'          => $request->get_param( 'image_size' ),
+			'image_height'        => $request->get_param( 'image_height' ),
+			'excerpt_length'      => $request->get_param( 'excerpt_length' ),
+			'style'               => $request->get_param( 'style' ),
+			'status'              => $request->get_param( 'status' ),
+		];
+
+		return new WP_REST_Response(
+			[
+				'status'  => true,
+				'content' => give_form_grid_shortcode( $attributes ),
+				'params'  => $attributes,
+			]
+		);
+	}
+
+}

--- a/src/Divi/resources/js/give-divi.js
+++ b/src/Divi/resources/js/give-divi.js
@@ -6,7 +6,8 @@ import DonorWall from '../../Modules/DonorWall';
 import FormGoal from '../../Modules/FormGoal';
 import RegistrationForm from '../../Modules/RegistrationForm';
 import LoginForm from '../../Modules/LoginForm';
+import FormGird from '../../Modules/FormGrid';
 
 $( window ).on( 'et_builder_api_ready', ( event, API ) => {
-	API.registerModules( [ DonationForm, DonorWall, FormGoal, RegistrationForm, LoginForm ] );
+	API.registerModules( [ DonationForm, DonorWall, FormGoal, RegistrationForm, LoginForm, FormGird ] );
 } );


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #21 

## Description

This PR adds support for the Form Grid shortcode functionality to be used as a Divi module.

## Affects

Adds new Give Form Grid Divi module.

## Visuals

![image](https://user-images.githubusercontent.com/4222590/105217761-90398000-5b54-11eb-8ecf-8698c6e06b8a.png)


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

1. Add a new page using Divi editor
2. Insert the Give Form Grid module
3. Test module on the front-end
