### PR TITLE
Add Donation History Module

### DIFF
--- a/src/Divi/Helpers/Modules.php
+++ b/src/Divi/Helpers/Modules.php
@@ -11,6 +11,7 @@ use GiveDivi\Divi\Modules\RegistrationForm\Module as RegistrationFormModule;
 use GiveDivi\Divi\Modules\LoginForm\Module as LoginFormModule;
 use GiveDivi\Divi\Modules\Totals\Module as TotalsModule;
 use GiveDivi\Divi\Modules\ProfileEditor\Module as ProfileEditorModule;
+use GiveDivi\Divi\Modules\DonationHistory\Module as DonationHistoryModule;
 
 // Module routes Routes
 use GiveDivi\Divi\Routes\RenderDonationForm;
@@ -21,6 +22,7 @@ use GiveDivi\Divi\Routes\RenderRegistrationForm;
 use GiveDivi\Divi\Routes\RenderLoginForm;
 use GiveDivi\Divi\Routes\RenderTotals;
 use GiveDivi\Divi\Routes\RenderProfileEditor;
+use GiveDivi\Divi\Routes\RenderDonationHistory;
 
 /**
  * Class Modules
@@ -49,8 +51,8 @@ class Modules {
 			[
 				'module' => DonationReceiptModule::class,
 				'route'  => RenderDonationReceipt::class,
-      ],
-      [
+			],
+			[
 				'module' => RegistrationFormModule::class,
 				'route'  => RenderRegistrationForm::class,
 			],
@@ -61,10 +63,14 @@ class Modules {
 			[
 				'module' => TotalsModule::class,
 				'route'  => RenderTotals::class,
-      ],
-      [
+			],
+			[
 				'module' => ProfileEditorModule::class,
 				'route'  => RenderProfileEditor::class,
+			],
+			[
+				'module' => DonationHistoryModule::class,
+				'route'  => RenderDonationHistory::class,
 			],
 		];
 	}
@@ -76,7 +82,7 @@ class Modules {
 	 */
 	public static function getModules() {
 		return array_map(
-			function( $module ) {
+			function ( $module ) {
 				return $module['module'];
 			},
 			static::config()
@@ -91,7 +97,7 @@ class Modules {
 	 */
 	public static function getRoutes() {
 		return array_map(
-			function( $module ) {
+			function ( $module ) {
 				return $module['route'];
 			},
 			static::config()

--- a/src/Divi/Modules/DonationHistory/Module.php
+++ b/src/Divi/Modules/DonationHistory/Module.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace GiveDivi\Divi\Modules\DonationHistory;
+
+class Module extends \ET_Builder_Module {
+	/**
+	 * @var string
+	 */
+	public $slug;
+
+	/**
+	 * @var string
+	 */
+	public $vb_support;
+
+	/**
+	 * @var string[]
+	 */
+	protected $module_credits;
+
+	/**
+	 * Module constructor.
+	 */
+	public function __construct() {
+		$this->slug           = 'give_donation_history';
+		$this->vb_support     = 'on';
+		$this->module_credits = [
+			'module_uri' => '',
+			'author'     => 'GiveWp',
+			'author_uri' => 'https://givewp.com',
+		];
+
+		parent::__construct();
+	}
+
+	public function init() {
+		$this->name = esc_html__( 'Give Donation History', 'give-divi' );
+	}
+
+	/**
+	 * Get module fields
+	 *
+	 * @return array[]
+	 */
+	public function get_fields() {
+		return [
+			'id'             => [
+				'label'           => esc_html__( 'Show Donation ID', 'give-divi' ),
+				'type'            => 'yes_no_button',
+				'option_category' => 'basic_option',
+				'options'         => [ 'off', 'on' ],
+				'default'         => 'on',
+				'description'     => esc_html__( 'Choose if you want to display the column with the ID of the donation.', 'give-divi' ),
+			],
+			'date'           => [
+				'label'           => esc_html__( 'Show Date', 'give-divi' ),
+				'type'            => 'yes_no_button',
+				'option_category' => 'basic_option',
+				'options'         => [ 'off', 'on' ],
+				'default'         => 'on',
+				'description'     => esc_html__( 'Choose if you want to display the column with the date the donation was made.', 'give-divi' ),
+			],
+			'donor'          => [
+				'label'           => esc_html__( 'Show Donor', 'give-divi' ),
+				'type'            => 'yes_no_button',
+				'option_category' => 'basic_option',
+				'options'         => [ 'off', 'on' ],
+				'default'         => 'off',
+				'description'     => esc_html__( 'Choose if you want to display the column with the donor’s full name.', 'give-divi' ),
+			],
+			'amount'         => [
+				'label'           => esc_html__( 'Show Amount', 'give-divi' ),
+				'type'            => 'yes_no_button',
+				'option_category' => 'basic_option',
+				'options'         => [ 'off', 'on' ],
+				'default'         => 'on',
+				'description'     => esc_html__( 'Choose if you want to display the column with the donation amount.', 'give-divi' ),
+			],
+			'status'         => [
+				'label'           => esc_html__( 'Show Payment Status', 'give-divi' ),
+				'type'            => 'yes_no_button',
+				'option_category' => 'basic_option',
+				'options'         => [ 'off', 'on' ],
+				'default'         => 'off',
+				'description'     => esc_html__( 'Choose if you want to display the column with the payment status of the donation.', 'give-divi' ),
+			],
+			'payment_method' => [
+				'label'           => esc_html__( 'Show Payment Method', 'give-divi' ),
+				'type'            => 'yes_no_button',
+				'option_category' => 'basic_option',
+				'options'         => [ 'off', 'on' ],
+				'default'         => 'off',
+				'description'     => esc_html__( 'Choose if you want to display the column with the payment method the donation was made with.', 'give-divi' ),
+			],
+		];
+	}
+
+	/**
+	 * Render Donation History
+	 *
+	 * @param  array  $attrs
+	 * @param  null  $content
+	 * @param  string  $render_slug
+	 *
+	 * @return string
+	 * @since 1.0.0
+	 */
+	public function render( $attrs, $content = null, $render_slug ) {
+		$attributes = [
+			'id'             => isset( $attrs['id'] ) ? filter_var( $attrs['id'], FILTER_VALIDATE_BOOLEAN ) : true,
+			'date'           => isset( $attrs['date'] ) ? filter_var( $attrs['date'], FILTER_VALIDATE_BOOLEAN ) : true,
+			'donor'          => isset( $attrs['donor'] ) ? filter_var( $attrs['donor'], FILTER_VALIDATE_BOOLEAN ) : false,
+			'amount'         => isset( $attrs['amount'] ) ? filter_var( $attrs['amount'], FILTER_VALIDATE_BOOLEAN ) : true,
+			'status'         => isset( $attrs['status'] ) ? filter_var( $attrs['status'], FILTER_VALIDATE_BOOLEAN ) : false,
+			'payment_method' => isset( $attrs['payment_method'] ) ? filter_var( $attrs['payment_method'], FILTER_VALIDATE_BOOLEAN ) : false,
+		];
+
+		return give_donation_history( $attributes );
+	}
+}

--- a/src/Divi/Modules/DonationHistory/index.js
+++ b/src/Divi/Modules/DonationHistory/index.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import API, { CancelToken } from '../../resources/js/api';
+import parse from 'html-react-parser';
+
+export default class DonationHistory extends React.Component {
+	static slug = 'give_donation_history';
+
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			fetching: false,
+			content: null,
+		};
+	}
+
+	getSnapshotBeforeUpdate( prevProps ) {
+		if (
+			prevProps.id !== this.props.id ||
+			prevProps.date !== this.props.date ||
+			prevProps.donor !== this.props.donor ||
+			prevProps.amount !== this.props.amount ||
+			prevProps.status !== this.props.status ||
+			prevProps.payment_method !== this.props.payment_method
+		) {
+			return {
+				id: this.props.id === 'on',
+				date: this.props.date === 'on',
+				donor: this.props.donor === 'on',
+				amount: this.props.amount === 'on',
+				status: this.props.status === 'on',
+				payment_method: this.props.payment_method === 'on',
+			};
+		}
+
+		return null;
+	}
+
+	componentDidMount() {
+		this.fetchDonationHistory(
+			{
+				id: this.props.id === 'on',
+				date: this.props.date === 'on',
+				donor: this.props.donor === 'on',
+				amount: this.props.amount === 'on',
+				status: this.props.status === 'on',
+				payment_method: this.props.payment_method === 'on',
+			}
+		);
+	}
+
+	componentDidUpdate( prevProps, prevState, snapshot ) {
+		if ( snapshot && ! this.state.fetching ) {
+			this.fetchDonationHistory( snapshot );
+		}
+	}
+
+	fetchDonationHistory( params ) {
+		this.setState(
+			{
+				fetching: true,
+			}
+		);
+
+		API.post( '/render-donation-history', params, { cancelToken: CancelToken.token } )
+			.then( ( response ) => {
+				this.setState( {
+					fetching: false,
+					content: response.data.content,
+				} );
+			} )
+			.catch( () => {
+				CancelToken.cancel();
+				this.setState( {
+					fetching: false,
+					content: '',
+				} );
+			} );
+	}
+
+	render() {
+		return (
+			<>{ this.state.content && parse( this.state.content ) }</>
+		);
+	}
+}

--- a/src/Divi/Routes/RenderDonationHistory.php
+++ b/src/Divi/Routes/RenderDonationHistory.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace GiveDivi\Divi\Routes;
+
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Class RenderDonationHistory
+ * @package GiveDivi\Divi\Routes
+ */
+class RenderDonationHistory extends Endpoint {
+
+	/** @var string */
+	protected $endpoint = 'give-divi/render-donation-history';
+
+
+	/**
+	 * @inheritDoc
+	 */
+	public function registerRoute() {
+		register_rest_route(
+			'give-api/v2',
+			$this->endpoint,
+			[
+				[
+					'methods'             => 'POST',
+					'callback'            => [ $this, 'handleRequest' ],
+					'permission_callback' => [ $this, 'permissionsCheck' ],
+					'args'                => [
+						'id'             => [
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => true,
+						],
+						'date'           => [
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => true,
+						],
+						'donor'          => [
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => false,
+						],
+						'amount'         => [
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => true,
+						],
+						'status'         => [
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => false,
+						],
+						'payment_method' => [
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => false,
+						],
+					],
+				],
+				'schema' => [ $this, 'getSchema' ],
+			]
+		);
+	}
+
+	/**
+	 * @return array
+	 * @since 1.0.0
+	 */
+	public function getSchema() {
+		return [
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'give-divi',
+			'type'       => 'object',
+			'properties' => [
+				'id'             => [
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Show Donation ID', 'give-divi' ),
+				],
+				'date'           => [
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Show Date', 'give-divi' ),
+				],
+				'donor'          => [
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Show Donor', 'give-divi' ),
+				],
+				'amount'         => [
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Show Amount', 'give-divi' ),
+				],
+				'status'         => [
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Show Payment Status', 'give-divi' ),
+				],
+				'payment_method' => [
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Show Payment Method', 'give-divi' ),
+				],
+			],
+		];
+	}
+
+	/**
+	 * @param  WP_REST_Request  $request
+	 *
+	 * @return WP_REST_Response
+	 * @since 1.0.0
+	 */
+	public function handleRequest( WP_REST_Request $request ) {
+		$attributes = [
+			'id'             => $request->get_param( 'id' ),
+			'date'           => $request->get_param( 'date' ),
+			'donor'          => $request->get_param( 'donor' ),
+			'amount'         => $request->get_param( 'amount' ),
+			'status'         => $request->get_param( 'status' ),
+			'payment_method' => $request->get_param( 'payment_method' ),
+		];
+
+		return new WP_REST_Response(
+			[
+				'status'  => true,
+				'content' => give_donation_history( $attributes ),
+			]
+		);
+	}
+
+}

--- a/src/Divi/resources/js/give-divi.js
+++ b/src/Divi/resources/js/give-divi.js
@@ -9,7 +9,8 @@ import RegistrationForm from '../../Modules/RegistrationForm';
 import LoginForm from '../../Modules/LoginForm';
 import Totals from '../../Modules/Totals';
 import ProfileEditor from '../../Modules/ProfileEditor';
+import DonationHistory from '../../Modules/DonationHistory';
 
 $( window ).on( 'et_builder_api_ready', ( event, API ) => {
-	API.registerModules( [ DonationForm, DonorWall, FormGoal, DonationReceipt, RegistrationForm, LoginForm, Totals, ProfileEditor ] )
+	API.registerModules( [ DonationForm, DonorWall, FormGoal, DonationReceipt, RegistrationForm, LoginForm, Totals, ProfileEditor, DonationHistory ] );
 } );


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #23 

## Description

This PR adds support for the Donation History shortcode functionality to be used as a Divi module.

## Affects

Adds new Give Donation History Divi module.

## Visuals

![image](https://user-images.githubusercontent.com/4222590/105324463-be0ddb80-5bcb-11eb-9fad-ca4bdc152eef.png)


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

1. Add a new page using Divi editor
2. Insert the Give Donation History module
3. Test module on the front-end
