### PR TITLE
Add Subscriptions Table Module

### DIFF
--- a/src/Divi/Helpers/Modules.php
+++ b/src/Divi/Helpers/Modules.php
@@ -11,6 +11,7 @@ use GiveDivi\Divi\Modules\RegistrationForm\Module as RegistrationFormModule;
 use GiveDivi\Divi\Modules\LoginForm\Module as LoginFormModule;
 use GiveDivi\Divi\Modules\Totals\Module as TotalsModule;
 use GiveDivi\Divi\Modules\ProfileEditor\Module as ProfileEditorModule;
+use GiveDivi\Divi\Modules\SubscriptionsTable\Module as SubscriptionsTableModule;
 
 // Module routes Routes
 use GiveDivi\Divi\Routes\RenderDonationForm;
@@ -21,6 +22,7 @@ use GiveDivi\Divi\Routes\RenderRegistrationForm;
 use GiveDivi\Divi\Routes\RenderLoginForm;
 use GiveDivi\Divi\Routes\RenderTotals;
 use GiveDivi\Divi\Routes\RenderProfileEditor;
+use GiveDivi\Divi\Routes\RenderSubscriptionTable;
 
 /**
  * Class Modules
@@ -49,8 +51,8 @@ class Modules {
 			[
 				'module' => DonationReceiptModule::class,
 				'route'  => RenderDonationReceipt::class,
-      ],
-      [
+			],
+			[
 				'module' => RegistrationFormModule::class,
 				'route'  => RenderRegistrationForm::class,
 			],
@@ -61,12 +63,50 @@ class Modules {
 			[
 				'module' => TotalsModule::class,
 				'route'  => RenderTotals::class,
-      ],
-      [
+			],
+			[
 				'module' => ProfileEditorModule::class,
 				'route'  => RenderProfileEditor::class,
 			],
+			[
+				'module' => SubscriptionsTableModule::class,
+				'route'  => RenderSubscriptionTable::class,
+				'active' => defined( 'GIVE_RECURRING_VERSION' ),
+			],
 		];
+	}
+
+	/**
+	 * @param $key
+	 *
+	 * @return array|string[]
+	 */
+	private static function getDefinitionsByKey( $key ) {
+		// Check key
+		if ( ! in_array( $key, [ 'module', 'route' ], true ) ) {
+			throw new \InvalidArgumentException(
+				sprintf( 'Invalid key %s', $key )
+			);
+		}
+
+		// Get active modules
+		$modules = array_filter(
+			static::config(),
+			function( $module ) {
+				if ( isset( $module['active'] ) && ! $module['active'] ) {
+					return false;
+				}
+
+				return true;
+			}
+		);
+
+		return array_map(
+			function( $module ) use ( $key ) {
+				return $module[ $key ];
+			},
+			$modules
+		);
 	}
 
 	/**
@@ -75,12 +115,7 @@ class Modules {
 	 * @return array
 	 */
 	public static function getModules() {
-		return array_map(
-			function( $module ) {
-				return $module['module'];
-			},
-			static::config()
-		);
+		return static::getDefinitionsByKey( 'module' );
 	}
 
 
@@ -90,11 +125,6 @@ class Modules {
 	 * @return array
 	 */
 	public static function getRoutes() {
-		return array_map(
-			function( $module ) {
-				return $module['route'];
-			},
-			static::config()
-		);
+		return static::getDefinitionsByKey( 'route' );
 	}
 }

--- a/src/Divi/Modules/SubscriptionsTable/Module.php
+++ b/src/Divi/Modules/SubscriptionsTable/Module.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace GiveDivi\Divi\Modules\SubscriptionsTable;
+
+class Module extends \ET_Builder_Module {
+	/**
+	 * @var string
+	 */
+	public $slug;
+
+	/**
+	 * @var string
+	 */
+	public $vb_support;
+
+	/**
+	 * @var string[]
+	 */
+	protected $module_credits;
+
+	/**
+	 * Module constructor.
+	 */
+	public function __construct() {
+		$this->slug           = 'give_subscription_table';
+		$this->vb_support     = 'on';
+		$this->module_credits = [
+			'module_uri' => '',
+			'author'     => 'GiveWp',
+			'author_uri' => 'https://givewp.com',
+		];
+
+		parent::__construct();
+	}
+
+	public function init() {
+		$this->name = esc_html__( 'Give Subscriptions Table', 'give-divi' );
+	}
+
+	/**
+	 * Get module fields
+	 *
+	 * @return array[]
+	 */
+	public function get_fields() {
+		return [
+			'show_status'            => [
+				'label'           => esc_html__( 'Show Status', 'give-divi' ),
+				'type'            => 'yes_no_button',
+				'option_category' => 'basic_option',
+				'options'         => [ 'off', 'on' ],
+				'default'         => 'on',
+			],
+			'show_renewal_date'      => [
+				'label'           => esc_html__( 'Show Renewal Date', 'give-divi' ),
+				'type'            => 'yes_no_button',
+				'option_category' => 'basic_option',
+				'options'         => [ 'off', 'on' ],
+				'default'         => 'on',
+			],
+			'show_progress'          => [
+				'label'           => esc_html__( 'Show Progress', 'give-divi' ),
+				'type'            => 'yes_no_button',
+				'option_category' => 'basic_option',
+				'options'         => [ 'off', 'on' ],
+				'default'         => 'off',
+			],
+			'show_start_date'        => [
+				'label'           => esc_html__( 'Show Start Date', 'give-divi' ),
+				'type'            => 'yes_no_button',
+				'option_category' => 'basic_option',
+				'options'         => [ 'off', 'on' ],
+				'default'         => 'off',
+			],
+			'show_end_date'          => [
+				'label'           => esc_html__( 'Show End Date', 'give-divi' ),
+				'type'            => 'yes_no_button',
+				'option_category' => 'basic_option',
+				'options'         => [ 'off', 'on' ],
+				'default'         => 'off',
+			],
+			'subscriptions_per_page' => [
+				'label'           => esc_html__( 'Show Subscriptions per page', 'give-divi' ),
+				'type'            => 'text',
+				'option_category' => 'basic_option',
+				'default'         => '16',
+			],
+			'pagination_type'        => [
+				'label'           => esc_html__( 'Pagination Type', 'give-divi' ),
+				'type'            => 'select',
+				'option_category' => 'basic_option',
+				'options'         => [
+					'next_and_previous' => esc_html__( 'Displays Previous and Next buttons', 'give-divi' ),
+					'numbered'          => esc_html__( 'Displays numbered links to page', 'give-divi' ),
+				],
+				'default'         => 'next_and_previous',
+			],
+		];
+	}
+
+	/**
+	 * Render Subscriptions Table
+	 *
+	 * @param  array  $attrs
+	 * @param  null  $content
+	 * @param  string  $render_slug
+	 *
+	 * @return string
+	 * @since 1.0.0
+	 */
+	public function render( $attrs, $content = null, $render_slug ) {
+		$attributes = [
+			'show_status'            => isset( $attrs['show_status'] ) ? filter_var( $attrs['show_status'], FILTER_VALIDATE_BOOLEAN ) : true,
+			'show_renewal_date'      => isset( $attrs['show_renewal_date'] ) ? filter_var( $attrs['show_renewal_date'], FILTER_VALIDATE_BOOLEAN ) : true,
+			'show_progress'          => isset( $attrs['show_progress'] ) ? filter_var( $attrs['show_progress'], FILTER_VALIDATE_BOOLEAN ) : false,
+			'show_start_date'        => isset( $attrs['show_start_date'] ) ? filter_var( $attrs['show_start_date'], FILTER_VALIDATE_BOOLEAN ) : false,
+			'show_end_date'          => isset( $attrs['show_end_date'] ) ? filter_var( $attrs['show_end_date'], FILTER_VALIDATE_BOOLEAN ) : false,
+			'subscriptions_per_page' => isset( $attrs['subscriptions_per_page'] ) ? (int) $attrs['subscriptions_per_page'] : 16,
+			'pagination_type'        => isset( $attrs['pagination_type'] ) ? esc_attr( $attrs['pagination_type'] ) : 'next_and_previous',
+		];
+
+		$recurringShortcodes = new \Give_Recurring_Shortcodes();
+
+		return $recurringShortcodes->give_subscriptions( $attributes );
+	}
+}

--- a/src/Divi/Modules/SubscriptionsTable/index.js
+++ b/src/Divi/Modules/SubscriptionsTable/index.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import API, { CancelToken } from '../../resources/js/api';
+import parse from 'html-react-parser';
+
+export default class SubscriptionTable extends React.Component {
+	static slug = 'give_subscription_table';
+
+	state = {
+		fetching: false,
+		content: null,
+	};
+
+	getSnapshotBeforeUpdate( prevProps ) {
+		if (
+			prevProps.show_status !== this.props.show_status ||
+			prevProps.show_renewal_date !== this.props.show_renewal_date ||
+			prevProps.show_progress !== this.props.show_progress ||
+			prevProps.show_start_date !== this.props.show_start_date ||
+			prevProps.show_end_date !== this.props.show_end_date ||
+			prevProps.subscriptions_per_page !== this.props.subscriptions_per_page ||
+			prevProps.pagination_type !== this.props.pagination_type
+		) {
+			return {
+				show_status: this.props.show_status === 'on',
+				show_renewal_date: this.props.show_renewal_date === 'on',
+				show_progress: this.props.show_progress === 'on',
+				show_start_date: this.props.show_start_date === 'on',
+				show_end_date: this.props.show_end_date === 'on',
+				subscriptions_per_page: this.props.subscriptions_per_page,
+				pagination_type: this.props.pagination_type,
+			};
+		}
+
+		return null;
+	}
+
+	componentDidMount() {
+		this.fetchSubscriptionTable(
+			{
+				show_status: this.props.show_status === 'on',
+				show_renewal_date: this.props.show_renewal_date === 'on',
+				show_progress: this.props.show_progress === 'on',
+				show_start_date: this.props.show_start_date === 'on',
+				show_end_date: this.props.show_end_date === 'on',
+				subscriptions_per_page: this.props.subscriptions_per_page,
+				pagination_type: this.props.pagination_type,
+			}
+		);
+	}
+
+	componentDidUpdate( prevProps, prevState, snapshot ) {
+		if ( snapshot && ! this.state.fetching ) {
+			this.fetchSubscriptionTable( snapshot );
+		}
+	}
+
+	fetchSubscriptionTable( params ) {
+		this.setState(
+			{
+				fetching: true,
+			}
+		);
+
+		API.post( '/render-subscription-table', params, { cancelToken: CancelToken.token } )
+			.then( ( response ) => {
+				this.setState( {
+					fetching: false,
+					content: response.data.content,
+				} );
+			} )
+			.catch( () => {
+				CancelToken.cancel();
+				this.setState( {
+					fetching: false,
+					content: '',
+				} );
+			} );
+	}
+
+	render() {
+		return (
+			<>{ this.state.content && parse( this.state.content ) }</>
+		);
+	}
+}

--- a/src/Divi/Routes/RenderSubscriptionTable.php
+++ b/src/Divi/Routes/RenderSubscriptionTable.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace GiveDivi\Divi\Routes;
+
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Class RenderSubscriptionTable
+ * @package GiveDivi\Divi\Routes
+ */
+class RenderSubscriptionTable extends Endpoint {
+
+	/** @var string */
+	protected $endpoint = 'give-divi/render-subscription-table';
+
+
+	/**
+	 * @inheritDoc
+	 */
+	public function registerRoute() {
+		register_rest_route(
+			'give-api/v2',
+			$this->endpoint,
+			[
+				[
+					'methods'             => 'POST',
+					'callback'            => [ $this, 'handleRequest' ],
+					'permission_callback' => [ $this, 'permissionsCheck' ],
+					'args'                => [
+						'show_status'            => [
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => true,
+						],
+						'show_renewal_date'      => [
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => true,
+						],
+						'show_progress'          => [
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => false,
+						],
+						'show_start_date'        => [
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => false,
+						],
+						'show_end_date'          => [
+							'type'     => 'boolean',
+							'required' => false,
+							'default'  => false,
+						],
+						'subscriptions_per_page' => [
+							'type'     => 'integer',
+							'required' => false,
+							'default'  => 16,
+						],
+						'pagination_type'        => [
+							'type'     => 'string',
+							'required' => false,
+							'default'  => 'next_and_previous',
+						],
+					],
+				],
+				'schema' => [ $this, 'getSchema' ],
+			]
+		);
+	}
+
+	/**
+	 * @return array
+	 * @since 1.0.0
+	 */
+	public function getSchema() {
+		return [
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'give-divi',
+			'type'       => 'object',
+			'properties' => [
+				'show_status'            => [
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Show Status', 'give-divi' ),
+				],
+				'show_renewal_date'      => [
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Show Renewal Date', 'give-divi' ),
+				],
+				'show_progress'          => [
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Show Progress', 'give-divi' ),
+				],
+				'show_start_date'        => [
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Show Start Date', 'give-divi' ),
+				],
+				'show_end_date'          => [
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Show End Date', 'give-divi' ),
+				],
+				'subscriptions_per_page' => [
+					'type'        => 'integer',
+					'description' => esc_html__( 'Show Subscriptions per page', 'give-divi' ),
+				],
+				'pagination_type'        => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Pagination Type', 'give-divi' ),
+				],
+			],
+		];
+	}
+
+	/**
+	 * @param  WP_REST_Request  $request
+	 *
+	 * @return WP_REST_Response
+	 * @since 1.0.0
+	 */
+	public function handleRequest( WP_REST_Request $request ) {
+		$attributes = [
+			'show_status'            => $request->get_param( 'show_status' ),
+			'show_renewal_date'      => $request->get_param( 'show_renewal_date' ),
+			'show_progress'          => $request->get_param( 'show_progress' ),
+			'show_start_date'        => $request->get_param( 'show_start_date' ),
+			'show_end_date'          => $request->get_param( 'show_end_date' ),
+			'subscriptions_per_page' => $request->get_param( 'subscriptions_per_page' ),
+			'pagination_type'        => $request->get_param( 'pagination_type' ),
+		];
+
+		$recurringShortcodes = new \Give_Recurring_Shortcodes();
+
+		return new WP_REST_Response(
+			[
+				'status'  => true,
+				'content' => $recurringShortcodes->give_subscriptions( $attributes ),
+			]
+		);
+	}
+
+}

--- a/src/Divi/resources/js/give-divi.js
+++ b/src/Divi/resources/js/give-divi.js
@@ -9,7 +9,8 @@ import RegistrationForm from '../../Modules/RegistrationForm';
 import LoginForm from '../../Modules/LoginForm';
 import Totals from '../../Modules/Totals';
 import ProfileEditor from '../../Modules/ProfileEditor';
+import SubscriptionsTable from '../../Modules/SubscriptionsTable';
 
 $( window ).on( 'et_builder_api_ready', ( event, API ) => {
-	API.registerModules( [ DonationForm, DonorWall, FormGoal, DonationReceipt, RegistrationForm, LoginForm, Totals, ProfileEditor ] )
+	API.registerModules( [ DonationForm, DonorWall, FormGoal, DonationReceipt, RegistrationForm, LoginForm, Totals, ProfileEditor, SubscriptionsTable ] );
 } );


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #25 

## Description

This PR adds support for the Subscriptions Table shortcode functionality of the Give Recurring add-on to be used as a Divi module.

## Affects

Adds new Give Subscriptions Table Divi module.

## Visuals

![image](https://user-images.githubusercontent.com/4222590/105390676-947ba100-5c19-11eb-842a-ae3faa2f6417.png)


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

**In order to test this module, Give Recurring add-on should be installed and activated** 

1. Add a new page using Divi editor
2. Insert the Give Subscriptions Table module
3. Test module on the front-end
