### PR TITLE
Update readme for .org purposes

### DIFF
--- a/give-divi.php
+++ b/give-divi.php
@@ -4,8 +4,8 @@ use GiveDivi\Addon\Environment;
 use GiveDivi\Divi\AddonServiceProvider;
 
 /**
- * Plugin Name: Give - Divi
- * Plugin URI:  https://givewp.com/addons/give-divi/
+ * Plugin Name: GiveWP Donation Modules for Divi
+ * Plugin URI:  https://go.givewp.com/divi-addon
  * Description: Use GiveWP shortcodes as Divi modules
  * Version:     1.0.0
  * Author:      GiveWP


### PR DESCRIPTION
When we submit the plugin, the slug is determined by the name of the plugin and that can't be changed later, so we need it to be correct. 

I also updated the Plugin URI since this will not be listed at our Addons section, but instead on the Free Addons page and as a shortlink.