### PR TITLE
The Donation Receipt module is now working regardless of the permalink settings

### DIFF
--- a/src/Divi/Helpers/Modules.php
+++ b/src/Divi/Helpers/Modules.php
@@ -72,7 +72,7 @@ class Modules {
 				'module' => ProfileEditorModule::class,
 				'route'  => RenderProfileEditor::class,
 			],
-      [
+			[
 				'module' => DonationHistoryModule::class,
 				'route'  => RenderDonationHistory::class,
 			],
@@ -80,7 +80,7 @@ class Modules {
 				'module' => SubscriptionsTableModule::class,
 				'route'  => RenderSubscriptionTable::class,
 				'active' => defined( 'GIVE_RECURRING_VERSION' ),
-      ],
+			],
 		];
 	}
 

--- a/src/Divi/Modules/DonationReceipt/Module.php
+++ b/src/Divi/Modules/DonationReceipt/Module.php
@@ -54,6 +54,15 @@ class Module extends \ET_Builder_Module {
 					'donor' => 'none', // always hidden
 				],
 			],
+			'pretty_urls'    => [
+				'label'           => 'Pretty URLs',
+				'type'            => 'text',
+				'option_category' => 'basic_option',
+				'default'         => ! empty( get_option( 'permalink_structure' ) ) ? 'on' : 'off',
+				'show_if'         => [
+					'donor' => 'none', // always hidden
+				],
+			],
 			'donor'          => [
 				'label'           => esc_html__( 'Display donor', 'give-divi' ),
 				'type'            => 'yes_no_button',

--- a/src/Divi/Modules/DonationReceipt/index.js
+++ b/src/Divi/Modules/DonationReceipt/index.js
@@ -63,7 +63,9 @@ export default class DonationReceipt extends React.Component {
 			error: this.props.error,
 		};
 
-		API.post( `/render-donation-receipt?donation_id=${ this.props.donation_id }`, params, { cancelToken: CancelToken.token } )
+		const delimiter = ( this.props.pretty_urls === 'on' ) ? '?' : '&';
+
+		API.post( `/render-donation-receipt${ delimiter }donation_id=${ this.props.donation_id }`, params, { cancelToken: CancelToken.token } )
 			.then( ( response ) => {
 				this.setState( {
 					fetching: false,

--- a/src/Divi/Modules/DonationReceipt/index.js
+++ b/src/Divi/Modules/DonationReceipt/index.js
@@ -65,6 +65,8 @@ export default class DonationReceipt extends React.Component {
 
 		const delimiter = ( this.props.pretty_urls === 'on' ) ? '?' : '&';
 
+		// The parameter donation_id is required by the give_display_donation_receipt function, the receipt won't load without it
+		// The dynamic delimiter is used to properly handle pretty URLs and plain URLs
 		API.post( `/render-donation-receipt${ delimiter }donation_id=${ this.props.donation_id }`, params, { cancelToken: CancelToken.token } )
 			.then( ( response ) => {
 				this.setState( {

--- a/src/Divi/Routes/RenderTotals.php
+++ b/src/Divi/Routes/RenderTotals.php
@@ -35,6 +35,7 @@ class RenderTotals extends Endpoint {
 						'ids'          => [
 							'type'     => 'string',
 							'required' => false,
+							'default'  => '',
 						],
 						'cats'         => [
 							'type'     => 'string',


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #31

## Description

This PR resolves the issue where the Donation Receipt Module didn't work when the site is not using pretty URLs.
The issue is solved by checking the `permalink_structure` option value and then based on that information set the endpoint URL.

## Affects

Donation Receipt module.


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

1. Change permalink structure to `Plain`
2. Add a new page using Divi editor
3. Insert the Give Donation Receipt module
4. Test module on the front-end
5. Change permalink structure to `Post name`
6. Test module on the front-end

