### PR TITLE
Add Multi Form Goal Module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ vendor
 
 # Assert directory
 assets/dist
+
+*.zip

--- a/give-divi.php
+++ b/give-divi.php
@@ -4,10 +4,10 @@ use GiveDivi\Addon\Environment;
 use GiveDivi\Divi\AddonServiceProvider;
 
 /**
- * Plugin Name: GiveWP Donation Modules for Divi
+ * Plugin Name: Give - Donation Modules for Divi
  * Plugin URI:  https://go.givewp.com/divi-addon
  * Description: Use GiveWP shortcodes as Divi modules
- * Version:     1.0.0
+ * Version:     1.0.0-alpha
  * Author:      GiveWP
  * Author URI:  https://givewp.com/
  * Text Domain: give-divi
@@ -19,7 +19,7 @@ defined( 'ABSPATH' ) or exit;
 define( 'GIVE_DIVI_ADDON_NAME', 'Give - Divi' );
 
 // Versions
-define( 'GIVE_DIVI_ADDON_VERSION', '1.0.0' );
+define( 'GIVE_DIVI_ADDON_VERSION', '1.0.0-alpha' );
 define( 'GIVE_DIVI_ADDON_MIN_GIVE_VERSION', '2.8.0' );
 
 // Add-on paths

--- a/give-divi.php
+++ b/give-divi.php
@@ -7,7 +7,7 @@ use GiveDivi\Divi\AddonServiceProvider;
  * Plugin Name: Give - Donation Modules for Divi
  * Plugin URI:  https://go.givewp.com/divi-addon
  * Description: Use GiveWP shortcodes as Divi modules
- * Version:     1.0.0-alpha
+ * Version:     1.0.0-alpha2
  * Author:      GiveWP
  * Author URI:  https://givewp.com/
  * Text Domain: give-divi
@@ -19,7 +19,7 @@ defined( 'ABSPATH' ) or exit;
 define( 'GIVE_DIVI_ADDON_NAME', 'Give - Divi' );
 
 // Versions
-define( 'GIVE_DIVI_ADDON_VERSION', '1.0.0-alpha' );
+define( 'GIVE_DIVI_ADDON_VERSION', '1.0.0-alpha2' );
 define( 'GIVE_DIVI_ADDON_MIN_GIVE_VERSION', '2.8.0' );
 
 // Add-on paths

--- a/src/Addon/Environment.php
+++ b/src/Addon/Environment.php
@@ -26,11 +26,6 @@ class Environment {
 		if ( ! static::giveMinRequiredVersionCheck() ) {
 			add_action( 'admin_notices', [ Notices::class, 'giveVersionError' ] );
 		}
-
-		// Check for Divi Builder
-		if ( ! static::isDiviBuilderActive() ) {
-			add_action( 'admin_notices', [ Notices::class, 'diviInactive' ] );
-		}
 	}
 
 	/**
@@ -51,15 +46,5 @@ class Environment {
 	 */
 	public static function isGiveActive() {
 		return defined( 'GIVE_VERSION' );
-	}
-
-	/**
-	 * Check if Divi Builder is in use.
-	 *
-	 * @since 1.0.0
-	 * @return bool
-	 */
-	public static function isDiviBuilderActive() {
-		return defined( 'ET_BUILDER_PLUGIN_VERSION' );
 	}
 }

--- a/src/Divi/AddonServiceProvider.php
+++ b/src/Divi/AddonServiceProvider.php
@@ -34,10 +34,7 @@ class AddonServiceProvider implements ServiceProvider {
 		Hooks::addAction( 'admin_init', License::class, 'check' );
 		Hooks::addAction( 'admin_init', ActivationBanner::class, 'show', 20 );
 
-		// Load add-on assets only if Divi builder is active
-		if ( Environment::isDiviBuilderActive() ) {
-			Hooks::addAction( 'wp_enqueue_scripts', Assets::class, 'loadAssets' );
-		}
+		Hooks::addAction( 'wp_enqueue_scripts', Assets::class, 'loadAssets' );
 
 		// Rest routes
 		foreach ( Modules::getRoutes() as $moduleRoute ) {

--- a/src/Divi/Helpers/Modules.php
+++ b/src/Divi/Helpers/Modules.php
@@ -14,6 +14,7 @@ use GiveDivi\Divi\Modules\Totals\Module as TotalsModule;
 use GiveDivi\Divi\Modules\ProfileEditor\Module as ProfileEditorModule;
 use GiveDivi\Divi\Modules\DonationHistory\Module as DonationHistoryModule;
 use GiveDivi\Divi\Modules\SubscriptionsTable\Module as SubscriptionsTableModule;
+use GiveDivi\Divi\Modules\MultiFormGoal\Module as MultiFormGoalModule;
 
 // Module routes Routes
 use GiveDivi\Divi\Routes\RenderDonationForm;
@@ -27,6 +28,7 @@ use GiveDivi\Divi\Routes\RenderTotals;
 use GiveDivi\Divi\Routes\RenderProfileEditor;
 use GiveDivi\Divi\Routes\RenderDonationHistory;
 use GiveDivi\Divi\Routes\RenderSubscriptionTable;
+use GiveDivi\Divi\Routes\RenderMultiFormGoal;
 
 /**
  * Class Modules
@@ -80,6 +82,10 @@ class Modules {
 				'module' => SubscriptionsTableModule::class,
 				'route'  => RenderSubscriptionTable::class,
 				'active' => defined( 'GIVE_RECURRING_VERSION' ),
+			],
+			[
+				'module' => MultiFormGoalModule::class,
+				'route'  => RenderMultiFormGoal::class,
 			],
 		];
 	}

--- a/src/Divi/Helpers/Modules.php
+++ b/src/Divi/Helpers/Modules.php
@@ -67,6 +67,10 @@ class Modules {
 				'route'  => RenderLoginForm::class,
 			],
 			[
+				'module' => FormGridModule::class,
+				'route'  => RenderFormGrid::class,
+			],
+			[
 				'module' => TotalsModule::class,
 				'route'  => RenderTotals::class,
 			],

--- a/src/Divi/Modules/MultiFormGoal/Module.php
+++ b/src/Divi/Modules/MultiFormGoal/Module.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace GiveDivi\Divi\Modules\MultiFormGoal;
+
+use GiveDivi\Divi\Repositories\Forms;
+use Give\MultiFormGoals\MultiFormGoal\Shortcode;
+
+class Module extends \ET_Builder_Module {
+
+	public $slug;
+	public $vb_support;
+
+	protected $module_credits;
+
+	/**
+	 * @var Forms
+	 */
+	private $forms;
+
+	public function __construct( Forms $forms ) {
+		$this->forms          = $forms;
+		$this->slug           = 'give_multi_form_goal';
+		$this->vb_support     = 'on';
+		$this->module_credits = [
+			'module_uri' => '',
+			'author'     => 'GiveWp',
+			'author_uri' => 'https://givewp.com',
+		];
+
+		parent::__construct();
+	}
+
+	public function init() {
+		$this->name = esc_html__( 'Give Multi Form Goal', 'give-divi' );
+	}
+
+	/**
+	 * Get module fields
+	 *
+	 * @return array[]
+	 */
+	public function get_fields() {
+		return [
+			'ids'        => [
+				'label'           => esc_html__( 'Donation Form IDs', 'give-divi' ),
+				'type'            => 'give_multi_select',
+				'option_category' => 'basic_option',
+				'default'         => '',
+				'options'         => $this->forms->getAll(),
+				'description'     => esc_html__( 'Choose the IDs of the forms you want to display in the multi-form goal.', 'give-divi' ),
+			],
+			'tags'       => [
+				'label'           => esc_html__( 'Tags', 'give-divi' ),
+				'type'            => 'text',
+				'option_category' => 'basic_option',
+				'default'         => '',
+				'description'     => esc_html__( 'If you have tags enabled in GiveWP, you can list the category IDs that you want displayed in this grid. A comma-separated list of form tag IDs will cause the grid to include only forms with those tags.', 'give-divi' ),
+			],
+			'categories' => [
+				'label'           => esc_html__( 'Categories', 'give-divi' ),
+				'type'            => 'text',
+				'option_category' => 'basic_option',
+				'default'         => '',
+				'description'     => esc_html__( 'If you have categories enabled in GiveWP, you can list the category IDs that you want displayed in this grid. A comma-separated list of form category IDs will cause the grid to include only forms from those categories.', 'give-divi' ),
+			],
+			'goal'       => [
+				'label'           => esc_html__( 'Goal Amount', 'give-divi' ),
+				'type'            => 'text',
+				'option_category' => 'basic_option',
+				'default'         => '1000',
+				'description'     => esc_html__( 'Choose the goal amount to be displayed in the multi-form goal card.', 'give-divi' ),
+			],
+			'enddate'    => [
+				'label'           => esc_html__( 'End Date', 'give-divi' ),
+				'type'            => 'text',
+				'option_category' => 'basic_option',
+				'default'         => '',
+				'description'     => esc_html__( 'Define when the multi-form goal should come to an end', 'give-divi' ),
+			],
+			'color'      => [
+				'label'           => esc_html__( 'Color', 'give-divi' ),
+				'type'            => 'text',
+				'option_category' => 'basic_option',
+				'default'         => '#28c77b',
+				'description'     => esc_html__( 'Choose the primary color of the multi-form goal card', 'give-divi' ),
+			],
+			'heading'    => [
+				'label'           => esc_html__( 'Heading Title', 'give-divi' ),
+				'type'            => 'text',
+				'option_category' => 'basic_option',
+				'default'         => 'Example Heading',
+				'description'     => esc_html__( 'Choose the heading to be displayed on the multi-form goal card.', 'give-divi' ),
+			],
+			'image'      => [
+				'label'           => esc_html__( 'Featured Image of the Card', 'give-divi' ),
+				'type'            => 'text',
+				'option_category' => 'basic_option',
+				'default'         => GIVE_PLUGIN_URL . 'assets/dist/images/onboarding-preview-form-image.min.jpg',
+				'description'     => esc_html__( 'Choose the image URL of the multi-form goal card.', 'give-divi' ),
+			],
+			'summary'    => [
+				'label'           => esc_html__( 'Summary', 'give-divi' ),
+				'type'            => 'text',
+				'option_category' => 'basic_option',
+				'default'         => 'This is a summary.',
+				'description'     => esc_html__( 'Choose the summary text placed below the heading title.', 'give-divi' ),
+			],
+		];
+	}
+
+	/**
+	 * Render multi-form goal
+	 *
+	 * @param  array  $attrs
+	 * @param  null  $content
+	 * @param  string  $render_slug
+	 *
+	 * @return string|void
+	 * @since 1.0.0
+	 */
+	public function render( $attrs, $content = null, $render_slug ) {
+		$attributes = [
+			'ids'        => isset( $attrs['ids'] ) ? esc_attr( $attrs['ids'] ) : '',
+			'tags'       => isset( $attrs['tags'] ) ? esc_attr( $attrs['tags'] ) : '',
+			'categories' => isset( $attrs['categories'] ) ? esc_attr( $attrs['categories'] ) : '',
+			'goal'       => isset( $attrs['goal'] ) ? (int) $attrs['goal'] : 1000,
+			'enddate'    => isset( $attrs['enddate'] ) ? esc_attr( $attrs['enddate'] ) : '#28c77b',
+			'heading'    => isset( $attrs['heading'] ) ? esc_html( $attrs['heading'] ) : '',
+			'image'      => isset( $attrs['image'] ) ? esc_url( $attrs['image'] ) : GIVE_PLUGIN_URL . 'assets/dist/images/onboarding-preview-form-image.min.jpg',
+			'summary'    => isset( $attrs['summary'] ) ? esc_html( $attrs['summary'] ) : 'This is a summary.',
+		];
+
+		$shortcode = new Shortcode();
+
+		return $shortcode->renderCallback( $attributes );
+	}
+}

--- a/src/Divi/Modules/MultiFormGoal/index.js
+++ b/src/Divi/Modules/MultiFormGoal/index.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import API, { CancelToken } from '../../resources/js/api';
+import parse from 'html-react-parser';
+
+export default class MultiFormGoal extends React.Component {
+	static slug = 'give_multi_form_goal';
+
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			fetching: false,
+			content: null,
+		};
+	}
+
+	getSnapshotBeforeUpdate( prevProps ) {
+		if (
+			prevProps.ids !== this.props.ids ||
+			prevProps.tags !== this.props.tags ||
+			prevProps.categories !== this.props.categories ||
+			prevProps.goal !== this.props.goal ||
+			prevProps.enddate !== this.props.enddate ||
+			prevProps.color !== this.props.color ||
+			prevProps.heading !== this.props.heading ||
+			prevProps.image !== this.props.image ||
+			prevProps.summary !== this.props.summary
+		) {
+			return {
+				ids: this.props.ids,
+				tags: this.props.tags,
+				categories: this.props.categories,
+				goal: this.props.goal,
+				enddate: this.props.enddate,
+				color: this.props.color,
+				heading: this.props.heading,
+				image: this.props.image,
+				summary: this.props.summary,
+			};
+		}
+
+		return null;
+	}
+
+	componentDidMount() {
+		const params = {
+			ids: this.props.ids,
+			tags: this.props.tags,
+			categories: this.props.categories,
+			goal: this.props.goal,
+			enddate: this.props.enddate,
+			color: this.props.color,
+			heading: this.props.heading,
+			image: this.props.image,
+			summary: this.props.summary,
+		};
+
+		this.fetchMultiFormGoal( params );
+	}
+
+	componentDidUpdate( prevProps, prevState, snapshot ) {
+		if ( snapshot && ! this.state.fetching ) {
+			this.fetchMultiFormGoal( snapshot );
+		}
+	}
+
+	fetchMultiFormGoal( params ) {
+		this.setState(
+			{
+				fetching: true,
+			}
+		);
+
+		API.post( '/render-multi-form-goal', params, { cancelToken: CancelToken.token } )
+			.then( ( response ) => {
+				this.setState( {
+					fetching: false,
+					content: response.data.content,
+				} );
+			} )
+			.catch( () => {
+				CancelToken.cancel();
+				this.setState( {
+					fetching: false,
+					content: '',
+				} );
+			} );
+	}
+
+	render() {
+		return (
+			<>{ this.state.content && parse( this.state.content ) }</>
+		);
+	}
+}

--- a/src/Divi/Routes/RenderMultiFormGoal.php
+++ b/src/Divi/Routes/RenderMultiFormGoal.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace GiveDivi\Divi\Routes;
+
+use WP_REST_Request;
+use WP_REST_Response;
+use Give\MultiFormGoals\MultiFormGoal\Shortcode;
+
+/**
+ * Class RenderMultiFormGoal
+ * @package GiveDivi\Divi\Routes
+ */
+class RenderMultiFormGoal extends Endpoint {
+
+	/** @var string */
+	protected $endpoint = 'give-divi/render-multi-form-goal';
+
+
+	/**
+	 * @inheritDoc
+	 */
+	public function registerRoute() {
+		register_rest_route(
+			'give-api/v2',
+			$this->endpoint,
+			[
+				[
+					'methods'             => 'POST',
+					'callback'            => [ $this, 'handleRequest' ],
+					'permission_callback' => [ $this, 'permissionsCheck' ],
+					'args'                => [
+						'ids'        => [
+							'type'     => 'string',
+							'required' => false,
+							'default'  => '',
+						],
+						'tags'       => [
+							'type'     => 'string',
+							'required' => false,
+							'default'  => '',
+						],
+						'categories' => [
+							'type'     => 'string',
+							'required' => false,
+							'default'  => '',
+						],
+						'goal'       => [
+							'type'     => 'integer',
+							'required' => false,
+							'default'  => 1000,
+						],
+						'enddate'    => [
+							'type'     => 'string',
+							'required' => false,
+							'default'  => '',
+						],
+						'color'      => [
+							'type'     => 'string',
+							'required' => false,
+							'default'  => '#28c77b',
+						],
+						'heading'    => [
+							'type'     => 'string',
+							'required' => false,
+							'default'  => 'Example Heading',
+						],
+						'image'      => [
+							'type'     => 'string',
+							'required' => false,
+							'default'  => GIVE_PLUGIN_URL . 'assets/dist/images/onboarding-preview-form-image.min.jpg',
+						],
+						'summary'    => [
+							'type'     => 'string',
+							'required' => false,
+							'default'  => 'This is a summary.',
+						],
+					],
+				],
+				'schema' => [ $this, 'getSchema' ],
+			]
+		);
+	}
+
+	/**
+	 * @return array
+	 * @since 1.0.0
+	 */
+	public function getSchema() {
+		return [
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'give-divi',
+			'type'       => 'object',
+			'properties' => [
+				'ids'        => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Donation Form IDs', 'give-divi' ),
+				],
+				'tags'       => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Tags', 'give-divi' ),
+				],
+				'categories' => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Categories', 'give-divi' ),
+				],
+				'goal'       => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Goal Amount', 'give-divi' ),
+				],
+				'enddate'    => [
+					'type'        => 'string',
+					'description' => esc_html__( 'End Date', 'give-divi' ),
+				],
+				'color'      => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Color', 'give-divi' ),
+				],
+				'heading'    => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Heading Title', 'give-divi' ),
+				],
+				'image'      => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Featured Image of the Card', 'give-divi' ),
+				],
+				'summary'    => [
+					'type'        => 'string',
+					'description' => esc_html__( 'Summary', 'give-divi' ),
+				],
+			],
+		];
+	}
+
+	/**
+	 * @param  WP_REST_Request  $request
+	 *
+	 * @return WP_REST_Response
+	 * @since 1.0.0
+	 */
+	public function handleRequest( WP_REST_Request $request ) {
+		$attributes = [
+			'ids'        => $request->get_param( 'ids' ),
+			'tags'       => $request->get_param( 'tags' ),
+			'categories' => $request->get_param( 'categories' ),
+			'goal'       => $request->get_param( 'goal' ),
+			'enddate'    => $request->get_param( 'enddate' ),
+			'heading'    => $request->get_param( 'heading' ),
+			'image'      => $request->get_param( 'image' ),
+			'summary'    => $request->get_param( 'summary' ),
+		];
+
+		$shortcode = new Shortcode();
+
+		return new WP_REST_Response(
+			[
+				'status'  => true,
+				'content' => $shortcode->renderCallback( $attributes ),
+			]
+		);
+	}
+}

--- a/src/Divi/resources/js/give-divi.js
+++ b/src/Divi/resources/js/give-divi.js
@@ -13,11 +13,12 @@ import ProfileEditor from '../../Modules/ProfileEditor';
 import DonationHistory from '../../Modules/DonationHistory';
 import FormGird from '../../Modules/FormGrid';
 import SubscriptionsTable from '../../Modules/SubscriptionsTable';
+import MultiFormGoal from '../../Modules/MultiFormGoal';
 
 // Custom fields
 import SimpleInput from '../../CustomFields/MultiSelect';
 
 $( window ).on( 'et_builder_api_ready', ( event, API ) => {
-	API.registerModules( [ DonationForm, DonorWall, FormGoal, DonationReceipt, RegistrationForm, LoginForm, Totals, ProfileEditor, DonationHistory, FormGird, SubscriptionsTable ] );
-  API.registerModalFields( [ SimpleInput ] );
+	API.registerModules( [ DonationForm, DonorWall, FormGoal, DonationReceipt, RegistrationForm, LoginForm, Totals, ProfileEditor, DonationHistory, FormGird, SubscriptionsTable, MultiFormGoal ] );
+	API.registerModalFields( [ SimpleInput ] );
 } );


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->
Blocked by https://github.com/impress-org/givewp/pull/5565

Resolves #35

## Description
This PR adds support for the Multi Form Goal shortcode functionality to be used as a Divi module.

## Affects
Adds new  Multi Form Goal Divi module.

## Visuals

![image](https://user-images.githubusercontent.com/4222590/105691993-35aa7600-5efe-11eb-85f0-758e226e7d9b.png)

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

1. Add a new page using Divi editor
2. Insert the Multi Form Goal module
3. Test module on the front-end

