### PR TITLE
Fix: Restore compatibility with latest Divi version

### DIFF
--- a/src/Divi/AddonServiceProvider.php
+++ b/src/Divi/AddonServiceProvider.php
@@ -4,10 +4,9 @@ namespace GiveDivi\Divi;
 
 use Give\Helpers\Hooks;
 use Give\ServiceProviders\ServiceProvider;
-use GiveDivi\Addon\Environment;
-use GiveDivi\Addon\License;
-use GiveDivi\Addon\Language;
 use GiveDivi\Addon\ActivationBanner;
+use GiveDivi\Addon\Language;
+use GiveDivi\Addon\License;
 use GiveDivi\Divi\Helpers\Assets;
 use GiveDivi\Divi\Helpers\Modules;
 

--- a/src/Divi/AddonServiceProvider.php
+++ b/src/Divi/AddonServiceProvider.php
@@ -42,7 +42,7 @@ class AddonServiceProvider implements ServiceProvider {
 
 		// Load GiveWP Divi modules
 		add_action(
-			'et_pagebuilder_module_init',
+			'et_builder_ready',
 			function () {
 				foreach ( Modules::getModules() as $module ) {
 					give( $module );


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #42

## Description

This PR resolves the issue where the plugin did not load correctly. The issue is resolved by using the correct hook to load the custom modules. 


## Testing Instructions

1. Install Divi theme. You can get it [here](https://drive.google.com/drive/u/0/folders/1S7O7r7GTMA7YS8NG8fBSP-Db7DbZVtCU).
2. Install and activate Give Divi plugin
3. Try to edit any page and insert Give Divi custom modules


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

