### PR TITLE
Feature: Give 3.0 compatibility

### DIFF
--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -1,0 +1,35 @@
+name: Generate Plugin Zip
+
+on:
+    workflow_dispatch:
+        inputs:
+            ref:
+                description: 'Git Commit Ref (branch, tag, or hash)'
+                required: true
+                type: string
+            production:
+                description: 'Is this a production build?'
+                default: false
+                type: boolean
+            slack_channel:
+                description: 'Slack channel ID to post to'
+                default: ''
+                required: false
+                type: string
+            slack_thread:
+                description: 'Slack thread to post to'
+                default: ''
+                required: false
+                type: string
+
+
+jobs:
+    build:
+        uses: impress-org/givewp-github-actions/.github/workflows/generate-zip.yml@master
+        with:
+            ref: ${{ github.event.inputs.ref }}
+            plugin_slug: give
+            production: ${{ github.event.inputs.production }}
+            slack_channel: ${{ github.event.inputs.slack_channel }}
+            slack_thread: ${{ github.event.inputs.slack_thread }}
+        secrets: inherit

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -28,7 +28,7 @@ jobs:
         uses: impress-org/givewp-github-actions/.github/workflows/generate-zip.yml@master
         with:
             ref: ${{ github.event.inputs.ref }}
-            plugin_slug: give
+            plugin_slug: give-divi
             production: ${{ github.event.inputs.production }}
             slack_channel: ${{ github.event.inputs.slack_channel }}
             slack_thread: ${{ github.event.inputs.slack_thread }}

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,10 @@
     },
     "config": {
         "platform": {
-            "php": "5.6.40"
+            "php": "7.2"
+        },
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     }
 }

--- a/src/Divi/Modules/DonationForm/Components/Iframe.js
+++ b/src/Divi/Modules/DonationForm/Components/Iframe.js
@@ -1,0 +1,22 @@
+import React, {createRef} from 'react';
+/**
+ * @unreleased
+ */
+export default function Iframe({dataSrc}) {
+    const iframe = createRef();
+
+    return (
+        <iframe
+            ref={iframe}
+            src={dataSrc}
+            style={{
+                width: '1px',
+                minWidth: '100%',
+                border: '0',
+            }}
+            onLoad={() => {
+                iframe.current.height = iframe.current.contentWindow.document.body.scrollHeight;
+            }}
+        />
+    );
+}

--- a/src/Divi/Modules/DonationForm/Components/ModalForm.js
+++ b/src/Divi/Modules/DonationForm/Components/ModalForm.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import {createPortal} from 'react-dom';
+import Iframe from './Iframe'
+
+/**
+ * @unreleased
+ */
+export default class ModalForm extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            isOpen: false
+        }
+    }
+    toggleModal = () => {
+        this.setState({
+            isOpen: !this.state.isOpen
+        });
+    };
+    render() {
+        return (
+            <div className={'givewp-donation-form-modal'}>
+                <button className={'givewp-donation-form-modal__open'} onClick={this.toggleModal}>
+                    Donate
+                </button>
+                {this.state.isOpen &&
+                    createPortal(
+                        <dialog className={'givewp-donation-form-modal__dialog'}>
+                            <button
+                                className="givewp-donation-form-modal__close"
+                                type="button"
+                                aria-label="Close"
+                                onClick={this.toggleModal}
+                            >
+                                <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    viewBox="0 0 24 24"
+                                    width="24"
+                                    height="24"
+                                    aria-hidden="true"
+                                    focusable="false"
+                                >
+                                    <path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path>
+                                </svg>
+                            </button>
+                            <Iframe dataSrc={dataSrc} />
+                        </dialog>,
+                        document.body
+                    )}
+            </div>
+        )
+    }
+}

--- a/src/Divi/Modules/DonationForm/Components/ModalForm.js
+++ b/src/Divi/Modules/DonationForm/Components/ModalForm.js
@@ -44,7 +44,7 @@ export default class ModalForm extends React.Component {
                                     <path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path>
                                 </svg>
                             </button>
-                            <Iframe dataSrc={dataSrc} />
+                            <Iframe dataSrc={this.props.dataSrc} />
                         </dialog>,
                         document.body
                     )}

--- a/src/Divi/Modules/DonationForm/Components/ModalForm.js
+++ b/src/Divi/Modules/DonationForm/Components/ModalForm.js
@@ -13,16 +13,16 @@ export default class ModalForm extends React.Component {
             isOpen: false
         }
     }
-    toggleModal = () => {
+    toggleModal() {
         this.setState({
             isOpen: !this.state.isOpen
         });
     };
     render() {
         return (
-            <div className={'givewp-donation-form-modal'}>
-                <button className={'givewp-donation-form-modal__open'} onClick={this.toggleModal}>
-                    Donate
+            <div className="givewp-donation-form-modal">
+                <button className="givewp-donation-form-modal__open" onClick={this.toggleModal}>
+                    {this.props.openFormButton}
                 </button>
                 {this.state.isOpen &&
                     createPortal(

--- a/src/Divi/Modules/DonationForm/Module.php
+++ b/src/Divi/Modules/DonationForm/Module.php
@@ -58,10 +58,13 @@ class Module extends ET_Builder_Module
     public function get_fields()
     {
         $donationForms = $this->forms->getAll();
+
         $donationFormsKeys = array_map(
             'strval',
             array_keys($donationForms)
         ); // Divi builder module requires array values to be a string
+
+        $v3formsKeys = array_map('strval',$this->forms->getV3Forms($donationFormsKeys));
 
         return [
             'id' => [
@@ -89,6 +92,10 @@ class Module extends ET_Builder_Module
                 'default' => 'on',
                 'show_if' => [
                     'id' => $donationFormsKeys,
+                    'style' => 'onpage',
+                ],
+                'show_if_not' => [
+                    'id' => $v3formsKeys,
                 ],
             ],
             'goal' => [
@@ -99,6 +106,19 @@ class Module extends ET_Builder_Module
                 'default' => 'on',
                 'show_if' => [
                     'id' => $donationFormsKeys,
+                    'style' => 'onpage',
+                ],
+                'show_if_not' => [
+                    'id' => $v3formsKeys,
+                ],
+            ],
+            'continue_button_title' => [
+                'label' => esc_html__('Button label', 'give-divi'),
+                'type' => 'text',
+                'option_category' => 'basic_option',
+                'default' =>  esc_html__('Donate', 'give-divi'),
+                'show_if_not' => [
+                    'style' => 'onpage',
                 ],
             ],
         ];

--- a/src/Divi/Modules/DonationForm/Module.php
+++ b/src/Divi/Modules/DonationForm/Module.php
@@ -64,8 +64,6 @@ class Module extends ET_Builder_Module
             array_keys($donationForms)
         ); // Divi builder module requires array values to be a string
 
-        $v3formsKeys = array_map('strval',$this->forms->getV3Forms($donationFormsKeys));
-
         return [
             'id' => [
                 'label' => esc_html__('Select Donation form', 'give-divi'),
@@ -93,10 +91,7 @@ class Module extends ET_Builder_Module
                 'show_if' => [
                     'id' => $donationFormsKeys,
                     'style' => 'onpage',
-                ],
-                'show_if_not' => [
-                    'id' => $v3formsKeys,
-                ],
+                ]
             ],
             'goal' => [
                 'label' => esc_html__('Display Donation goal', 'give-divi'),
@@ -107,10 +102,7 @@ class Module extends ET_Builder_Module
                 'show_if' => [
                     'id' => $donationFormsKeys,
                     'style' => 'onpage',
-                ],
-                'show_if_not' => [
-                    'id' => $v3formsKeys,
-                ],
+                ]
             ],
             'continue_button_title' => [
                 'label' => esc_html__('Button label', 'give-divi'),
@@ -146,15 +138,22 @@ class Module extends ET_Builder_Module
             $attrs['style'] = 'newTab';
         }
 
-        $atts = [
-            'id' => $attrs['id'],
-            'display_style' => $attrs['style'] ?? 'onpage',
-            'show_title' => isset($attrs['title']) ? filter_var($attrs['title'], FILTER_VALIDATE_BOOLEAN) : true,
-            'show_goal' => isset($attrs['goal']) ? filter_var($attrs['goal'], FILTER_VALIDATE_BOOLEAN) : true,
-            'continue_button_title' => $attrs['continue_button_title'] ?? 'Donate',
-        ];
+        $style = $attrs['style'] ?? 'onpage';
+        $title = isset($attrs['title'])
+            ? filter_var($attrs['title'], FILTER_VALIDATE_BOOLEAN)
+            : true;
+        $goal = isset($attrs['goal'])
+            ? filter_var($attrs['goal'], FILTER_VALIDATE_BOOLEAN)
+            : true;
+        $buttonLabel = $attrs['continue_button_title'] ?? 'Donate';
 
-        return give_form_shortcode($atts);
+        return give_form_shortcode([
+            'id' => $attrs['id'],
+            'display_style' => $style,
+            'show_title' => $title,
+            'show_goal' => $goal,
+            'continue_button_title' => $buttonLabel,
+        ]);
     }
 
 }

--- a/src/Divi/Modules/DonationForm/Module.php
+++ b/src/Divi/Modules/DonationForm/Module.php
@@ -142,11 +142,16 @@ class Module extends ET_Builder_Module
             return;
         }
 
+        if (isset($attrs['style']) && $attrs['style'] === 'button') {
+            $attrs['style'] = 'newTab';
+        }
+
         $atts = [
             'id' => $attrs['id'],
-            'display_style' => isset($attrs['style']) ? $attrs['style'] : 'onpage',
+            'display_style' => $attrs['style'] ?? 'onpage',
             'show_title' => isset($attrs['title']) ? filter_var($attrs['title'], FILTER_VALIDATE_BOOLEAN) : true,
             'show_goal' => isset($attrs['goal']) ? filter_var($attrs['goal'], FILTER_VALIDATE_BOOLEAN) : true,
+            'continue_button_title' => $attrs['continue_button_title'] ?? 'Donate',
         ];
 
         return give_form_shortcode($atts);

--- a/src/Divi/Modules/DonationForm/Module.php
+++ b/src/Divi/Modules/DonationForm/Module.php
@@ -121,14 +121,14 @@ class Module extends ET_Builder_Module
      *
      * @since 1.0.0
      *
-     * @param null $content
+     * @param string|null $content
      * @param string $render_slug
      *
      * @param array $attrs
      *
      * @return string|void
      */
-    public function render($attrs, $content = null, $render_slug)
+    public function render($attrs, $content, $render_slug)
     {
         if ( ! isset($attrs['id']) || ! boolval($attrs['id'])) {
             return;

--- a/src/Divi/Modules/DonationForm/index.js
+++ b/src/Divi/Modules/DonationForm/index.js
@@ -3,7 +3,7 @@ import React from 'react';
 import API, {CancelToken} from '../../resources/js/api';
 import parse from 'html-react-parser';
 import Iframe from './Components/Iframe';
-import ModalForm from "./Components/ModalForm";
+import ModalForm from './Components/ModalForm';
 
 import './styles.scss';
 
@@ -64,7 +64,7 @@ export default class DonationForm extends React.Component {
 
     fetchDonationForm(params) {
         this.setState({
-            fetching: true,
+            fetching: true
         });
 
         API.post('/render-donation-form', params, {cancelToken: CancelToken.token})
@@ -72,7 +72,7 @@ export default class DonationForm extends React.Component {
                this.setState({
                    fetching: false,
                    content: response.data.content,
-                   isV3Form: response.data.isV3Form,
+                   isV3Form: response.data?.isV3Form,
                    dataSrc: response.data?.dataSrc,
                    viewUrl: response.data?.viewUrl
                });

--- a/src/Divi/Modules/DonationForm/index.js
+++ b/src/Divi/Modules/DonationForm/index.js
@@ -5,6 +5,8 @@ import parse from 'html-react-parser';
 import Iframe from './Components/Iframe';
 import ModalForm from "./Components/ModalForm";
 
+import './styles.scss';
+
 export default class DonationForm extends React.Component {
     static slug = 'give_donation_form';
 
@@ -13,6 +15,7 @@ export default class DonationForm extends React.Component {
         content: null,
         isV3Form: null,
         dataSrc: null,
+        viewUrl: null
     };
 
     constructor(props) {
@@ -26,13 +29,15 @@ export default class DonationForm extends React.Component {
             prevProps.id !== this.props.id ||
             prevProps.style !== this.props.style ||
             prevProps.title !== this.props.title ||
-            prevProps.goal !== this.props.goal
+            prevProps.goal !== this.props.goal ||
+            prevProps.continue_button_title !== this.props.continue_button_title
         ) {
             return {
                 id: this.props.id,
                 style: this.props.style,
                 title: this.props.title === 'on',
                 goal: this.props.goal === 'on',
+                continue_button_title: this.props.continue_button_title
             };
         }
 
@@ -46,6 +51,7 @@ export default class DonationForm extends React.Component {
                 style: this.props.style,
                 title: this.props.title === 'on',
                 goal: this.props.goal === 'on',
+                continue_button_title: this.props.continue_button_title
             });
         }
     }
@@ -68,6 +74,7 @@ export default class DonationForm extends React.Component {
                    content: response.data.content,
                    isV3Form: response.data.isV3Form,
                    dataSrc: response.data?.dataSrc,
+                   viewUrl: response.data?.viewUrl
                });
            })
            .catch(() => {
@@ -80,14 +87,14 @@ export default class DonationForm extends React.Component {
         if (this.state.isV3Form) {
             if (this.props.style === 'button') {
                 return (
-                    <a className="givewp-donation-form-link" href={formUrl} target="_blank" rel="noopener noreferrer">
-                        {'Donate'}
+                    <a className="givewp-donation-form-link" href={this.state.viewUrl} target="_blank" rel="noopener noreferrer">
+                        {this.props.continue_button_title}
                     </a>
                 );
             }
 
             if (['modal', 'reveal'].includes(this.props.style)) {
-                return <ModalForm openFormButton={'Donate'} dataSrc={this.state.dataSrc} />;
+                return <ModalForm openFormButton={this.props.continue_button_title} dataSrc={this.state.dataSrc} />;
             }
 
             return <Iframe dataSrc={this.state.dataSrc} />;

--- a/src/Divi/Modules/DonationForm/styles.scss
+++ b/src/Divi/Modules/DonationForm/styles.scss
@@ -1,0 +1,40 @@
+.givewp-donation-form-link, .givewp-donation-form-modal__open {
+    color: var(--givewp-secondary-color, #ffffff) !important;
+    background: var(--givewp-primary-color, #2271b1) !important;
+    padding: .75rem 1.25rem !important;
+    cursor: pointer;
+    border: none;
+    border-radius: 5px !important;
+    font-size: 1rem;
+    font-weight: 500 !important;
+    text-decoration: none !important;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;;
+}
+
+.givewp-donation-form-modal {
+    border: none;
+
+    &__dialog {
+        position: relative;
+        padding: 0 !important;
+        border: none !important;
+    }
+
+    &__close {
+        position: absolute;
+        right: 3.5%;
+        top: 1.5%;
+        margin-right: auto;
+        padding: .5rem .5rem .25rem .5rem;
+        border: none !important;
+        background-color: transparent !important;
+        cursor: pointer;
+
+
+        &:hover {
+            path {
+                fill: #0073AA;
+            }
+        }
+    }
+}

--- a/src/Divi/Repositories/Forms.php
+++ b/src/Divi/Repositories/Forms.php
@@ -3,6 +3,7 @@
 namespace GiveDivi\Divi\Repositories;
 
 use Give_Forms_Query;
+use Give\Helpers\Form\Utils;
 
 /**
  * Class Forms
@@ -48,9 +49,7 @@ class Forms
         $output = [];
 
         foreach ($forms as $id) {
-            $isV3Form = (bool)give()->form_meta->get_meta($id, 'formBuilderSettings', true);
-
-            if ($isV3Form) {
+            if (Utils::isV3Form($id)) {
                 $output[] = $id;
             }
         }

--- a/src/Divi/Repositories/Forms.php
+++ b/src/Divi/Repositories/Forms.php
@@ -37,6 +37,28 @@ class Forms
     }
 
     /**
+     * @unreleased
+     *
+     * @param array $forms
+     *
+     * @return array
+     */
+    public function getV3Forms($forms)
+    {
+        $output = [];
+
+        foreach ($forms as $id) {
+            $isV3Form = (bool)give()->form_meta->get_meta($id, 'formBuilderSettings', true);
+
+            if ($isV3Form) {
+                $output[] = $id;
+            }
+        }
+
+        return $output;
+    }
+
+    /**
      * Get Donation form formats
      *
      * @since 1.0.0

--- a/src/Divi/Routes/RenderDonationForm.php
+++ b/src/Divi/Routes/RenderDonationForm.php
@@ -4,6 +4,7 @@ namespace GiveDivi\Divi\Routes;
 
 use Give\DonationForms\Actions\GenerateDonationFormPreviewRouteUrl;
 use Give\DonationForms\Actions\GenerateDonationFormViewRouteUrl;
+use Give\DonationForms\Models\DonationForm;
 use WP_REST_Request;
 use WP_REST_Response;
 
@@ -115,6 +116,12 @@ class RenderDonationForm extends Endpoint
         $isV3Form = (bool)give()->form_meta->get_meta($request->get_param('id'), 'formBuilderSettings', true);
 
         if ($isV3Form) {
+            if ($donationForm = DonationForm::find($attributes['id'])) {
+                $donationForm->settings->showHeading        = boolval($attributes['show_title']);
+                $donationForm->settings->enableDonationGoal = boolval($attributes['show_goal']);
+                $donationForm->save();
+            }
+
             return new WP_REST_Response(
                 [
                     'status' => true,

--- a/src/Divi/Routes/RenderDonationForm.php
+++ b/src/Divi/Routes/RenderDonationForm.php
@@ -2,6 +2,7 @@
 
 namespace GiveDivi\Divi\Routes;
 
+use Give\DonationForms\Actions\GenerateDonationFormPreviewRouteUrl;
 use Give\DonationForms\Actions\GenerateDonationFormViewRouteUrl;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -101,6 +102,7 @@ class RenderDonationForm extends Endpoint
             'display_style' => $request->get_param('style'),
             'show_title' => $request->get_param('title'),
             'show_goal' => $request->get_param('goal'),
+            'continue_button_title' => $request->get_param('continue_button_title'),
         ];
 
         $_SERVER['QUERY_STRING'] = [
@@ -118,6 +120,7 @@ class RenderDonationForm extends Endpoint
                     'status' => true,
                     'isV3Form' => true,
                     'dataSrc' => (new GenerateDonationFormViewRouteUrl())($request->get_param('id')),
+                    'viewUrl' => (new GenerateDonationFormPreviewRouteUrl())($request->get_param('id')),
                     'content' => give_form_shortcode($attributes),
                 ]
             );

--- a/src/Divi/Routes/RenderDonationForm.php
+++ b/src/Divi/Routes/RenderDonationForm.php
@@ -2,6 +2,7 @@
 
 namespace GiveDivi\Divi\Routes;
 
+use Give\DonationForms\Actions\GenerateDonationFormViewRouteUrl;
 use WP_REST_Request;
 use WP_REST_Response;
 
@@ -108,6 +109,19 @@ class RenderDonationForm extends Endpoint
             'rest' => true,
             // used as a flag to determine if reveal iframe script should be loaded
         ];
+
+        $isV3Form = (bool)give()->form_meta->get_meta($request->get_param('id'), 'formBuilderSettings', true);
+
+        if ($isV3Form) {
+            return new WP_REST_Response(
+                [
+                    'status' => true,
+                    'isV3Form' => true,
+                    'dataSrc' => (new GenerateDonationFormViewRouteUrl())($request->get_param('id')),
+                    'content' => give_form_shortcode($attributes),
+                ]
+            );
+        }
 
         return new WP_REST_Response(
             [


### PR DESCRIPTION
<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves [GIVE-69]

## Description

This PR adds compatibility for the new V3 forms.  There are some limitations due to how the v3 form works, and options to display the form title and form goal are not working as other options (these options are saved, but there is no preview in Divi builder)  Also, it was not possible to reuse the existing codebase for displaying the form as Divi builder uses class-based components and we are using functional components with hooks. 

## Affects
Donation form module


## Testing Instructions

Install Give
Install Divi builder
Install Give Divi add-on
Create v2 and v3 forms
Create a page using Divi builder
Insert the Donation Form module and select the form to display


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-69]: https://stellarwp.atlassian.net/browse/GIVE-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ